### PR TITLE
Add role class

### DIFF
--- a/src/main/java/seedu/address/model/role/Deadline.java
+++ b/src/main/java/seedu/address/model/role/Deadline.java
@@ -1,0 +1,66 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Represents a Role's deadline in the role list.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDeadline(String)}
+ */
+public class Deadline {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Deadlines should be in the following format: dd-MM-yyyy HH:mm";
+
+    public static final DateTimeFormatter VALIDATION_FORMATTER
+            = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+    public static final DateTimeFormatter STRING_REPRESENTATION_FORMATTER
+            = DateTimeFormatter.ofPattern("E, MMM dd yyyy, HH:mm a");
+
+    public final LocalDateTime value;
+
+    /**
+     * Constructs a {@code Deadline}.
+     *
+     * @param deadline A valid deadline.
+     */
+    public Deadline(String deadline) {
+        requireNonNull(deadline);
+        checkArgument(isValidDeadline(deadline), MESSAGE_CONSTRAINTS);
+        value = LocalDateTime.parse(deadline, VALIDATION_FORMATTER);
+    }
+
+    /**
+     * Returns true if a given string is a valid deadline.
+     */
+    public static boolean isValidDeadline(String test) {
+        try {
+            VALIDATION_FORMATTER.parse(test);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return value.format(STRING_REPRESENTATION_FORMATTER);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Deadline // instanceof handles nulls
+                && value.equals(((Deadline) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/role/Deadline.java
+++ b/src/main/java/seedu/address/model/role/Deadline.java
@@ -16,10 +16,10 @@ public class Deadline {
     public static final String MESSAGE_CONSTRAINTS =
             "Deadlines should be in the following format: dd-MM-yyyy HH:mm";
 
-    public static final DateTimeFormatter VALIDATION_FORMATTER
-            = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
-    public static final DateTimeFormatter STRING_REPRESENTATION_FORMATTER
-            = DateTimeFormatter.ofPattern("E, MMM dd yyyy, HH:mm a");
+    public static final DateTimeFormatter VALIDATION_FORMATTER =
+            DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+    public static final DateTimeFormatter STRING_REPRESENTATION_FORMATTER =
+            DateTimeFormatter.ofPattern("E, MMM dd yyyy, HH:mm a");
 
     public final LocalDateTime value;
 

--- a/src/main/java/seedu/address/model/role/Description.java
+++ b/src/main/java/seedu/address/model/role/Description.java
@@ -1,0 +1,57 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Role's description in the role list.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDescription(String)}
+ */
+public class Description {
+
+    public static final String MESSAGE_CONSTRAINTS = "Descriptions can take any values, and it should not be blank";
+
+    /*
+     * The first character of the description must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code Description}.
+     *
+     * @param description A valid description.
+     */
+    public Description(String description) {
+        requireNonNull(description);
+        checkArgument(isValidDescription(description), MESSAGE_CONSTRAINTS);
+        value = description;
+    }
+
+    /**
+     * Returns true if a given string is a valid email.
+     */
+    public static boolean isValidDescription(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Description // instanceof handles nulls
+                && value.equals(((Description) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/role/Name.java
+++ b/src/main/java/seedu/address/model/role/Name.java
@@ -1,0 +1,58 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Role's name in the role list.
+ * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
+ */
+public class Name {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the address must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String fullName;
+
+    /**
+     * Constructs a {@code Name}.
+     *
+     * @param name A valid name.
+     */
+    public Name(String name) {
+        requireNonNull(name);
+        checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
+        fullName = name;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidName(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return fullName;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Name // instanceof handles nulls
+                && fullName.equals(((Name) other).fullName)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return fullName.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/role/Role.java
+++ b/src/main/java/seedu/address/model/role/Role.java
@@ -1,0 +1,72 @@
+package seedu.address.model.role;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+/**
+ * Represents a Role in Tinner.
+ * Guarantees: details are present and not null, field values are validated, immutable.
+ */
+public class Role {
+
+    private final Name name;
+    private final Status status;
+    private final Deadline deadline;
+
+    // "optional" in the sense that they can be empty strings
+    private final Description description;
+    private final Stipend stipend;
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Role(Name name, Status status, Deadline deadline, Description description, Stipend stipend) {
+        requireAllNonNull(name, status, deadline, description, stipend);
+        this.name = name;
+        this.status = status;
+        this.deadline = deadline;
+        this.description = description;
+        this.stipend = stipend;
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public Deadline getDeadline() {
+        return deadline;
+    }
+
+    public Description getDescription() {
+        return description;
+    }
+
+    public Stipend getStipend() {
+        return stipend;
+    }
+
+    /**
+     * Returns true if both roles have the same fields.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Role)) {
+            return false;
+        }
+
+        Role otherRole = (Role) other;
+        return otherRole.getName().equals(getName())
+                && otherRole.getStatus().equals(getStatus())
+                && otherRole.getDeadline().equals(getDeadline())
+                && otherRole.getDescription().equals(getDescription())
+                && otherRole.getStipend().equals(getStipend());
+    }
+
+}

--- a/src/main/java/seedu/address/model/role/Status.java
+++ b/src/main/java/seedu/address/model/role/Status.java
@@ -1,0 +1,56 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.Arrays;
+
+/**
+ * Represents a Role's application status in the role list.
+ * Guarantees: immutable; is valid as declared in {@link #isValidStatus(String)}
+ */
+public class Status {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Status should only be one from the following: \"applying\", \"pending\", "
+                    + "\"offered\", \"rejected\", \"complete\"";
+    public static final String[] VALIDATION_ARRAY =
+            new String[]{"applying", "pending", "offered", "rejected", "complete"};
+    public final String value;
+
+    /**
+     * Constructs a {@code Status}.
+     *
+     * @param status A valid status.
+     */
+    public Status(String status) {
+        requireNonNull(status);
+        checkArgument(isValidStatus(status), MESSAGE_CONSTRAINTS);
+        value = status;
+    }
+
+    /**
+     * Returns true if a given string is a valid status.
+     */
+    public static boolean isValidStatus(String test) {
+        return Arrays.asList(VALIDATION_ARRAY).contains(test);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Status // instanceof handles nulls
+                && value.equals(((Status) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/role/Stipend.java
+++ b/src/main/java/seedu/address/model/role/Stipend.java
@@ -11,7 +11,7 @@ public class Stipend {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Stipends should only contain numbers, and it should be at most 10 digits long";
-    public static final String VALIDATION_REGEX = "\\d{0,10}";
+    public static final String VALIDATION_REGEX = "\\d{1,10}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/role/Stipend.java
+++ b/src/main/java/seedu/address/model/role/Stipend.java
@@ -1,0 +1,51 @@
+package seedu.address.model.role;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Role's stipend in Tinner.
+ * Guarantees: immutable; is valid as declared in {@link #isValidStipend(String)}
+ */
+public class Stipend {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Stipends should only contain numbers, and it should be at most 10 digits long";
+    public static final String VALIDATION_REGEX = "\\d{0,10}";
+    public final String value;
+
+    /**
+     * Constructs a {@code Stipend}.
+     *
+     * @param stipend A valid stipend.
+     */
+    public Stipend(String stipend) {
+        requireNonNull(stipend);
+        checkArgument(isValidStipend(stipend), MESSAGE_CONSTRAINTS);
+        value = stipend;
+    }
+
+    /**
+     * Returns true if a given string is a valid phone number.
+     */
+    public static boolean isValidStipend(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Stipend // instanceof handles nulls
+                && value.equals(((Stipend) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/test/java/seedu/address/model/role/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/role/DeadlineTest.java
@@ -1,0 +1,37 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DeadlineTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Deadline(null));
+    }
+
+    @Test
+    public void constructor_invalidDeadline_throwsIllegalArgumentException() {
+        String invalidDeadline = "";
+        assertThrows(IllegalArgumentException.class, () -> new Deadline(invalidDeadline));
+    }
+
+    @Test
+    public void isValidDeadline() {
+        // null deadline
+        assertThrows(NullPointerException.class, () -> Deadline.isValidDeadline(null));
+
+        // invalid deadlines
+        assertFalse(Deadline.isValidDeadline("")); // empty string
+        assertFalse(Deadline.isValidDeadline(" ")); // spaces only
+        assertFalse(Deadline.isValidDeadline("00-00-0000 00:00")); // invalid date format
+
+        // valid deadlines
+        assertTrue(Deadline.isValidDeadline("15-06-2001 11:00"));
+        assertTrue(Deadline.isValidDeadline("24-02-2022 20:49"));
+    }
+
+}

--- a/src/test/java/seedu/address/model/role/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/role/DescriptionTest.java
@@ -1,0 +1,36 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class DescriptionTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Description(null));
+    }
+
+    @Test
+    public void constructor_invalidDescription_throwsIllegalArgumentException() {
+        String invalidDescription = "";
+        assertThrows(IllegalArgumentException.class, () -> new Description(invalidDescription));
+    }
+
+    @Test
+    public void isValidDescription() {
+        // null description
+        assertThrows(NullPointerException.class, () -> Description.isValidDescription(null));
+
+        // invalid descriptions
+        assertFalse(Description.isValidDescription((""))); // empty string
+        assertFalse(Description.isValidDescription((" "))); // spaces only
+
+        // valid descriptions
+        assertTrue(Description.isValidDescription(("Work-from-home conditions.")));
+        assertTrue(Description.isValidDescription(("-"))); // one character
+        assertTrue(Description.isValidDescription(("Based in the States; consider work visa")));
+    }
+}

--- a/src/test/java/seedu/address/model/role/NameTest.java
+++ b/src/test/java/seedu/address/model/role/NameTest.java
@@ -1,0 +1,40 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class NameTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Name(null));
+    }
+
+    @Test
+    public void constructor_invalidName_throwsIllegalArgumentException() {
+        String invalidName = "";
+        assertThrows(IllegalArgumentException.class, () -> new Name(invalidName));
+    }
+
+    @Test
+    public void isValidName() {
+        // null name
+        assertThrows(NullPointerException.class, () -> Name.isValidName(null));
+
+        // invalid name
+        assertFalse(Name.isValidName("")); // empty string
+        assertFalse(Name.isValidName(" ")); // spaces only
+        assertFalse(Name.isValidName("^")); // only non-alphanumeric characters
+        assertFalse(Name.isValidName("technician*")); // contains non-alphanumeric characters
+
+        // valid name
+        assertTrue(Name.isValidName("software engineer")); // alphabets only
+        assertTrue(Name.isValidName("12345")); // numbers only
+        assertTrue(Name.isValidName("data analyst 2")); // alphanumeric characters
+        assertTrue(Name.isValidName("Frontend Developer")); // with capital letters
+        assertTrue(Name.isValidName("Database Management and Server Integration")); // long names
+    }
+}

--- a/src/test/java/seedu/address/model/role/RoleTest.java
+++ b/src/test/java/seedu/address/model/role/RoleTest.java
@@ -1,0 +1,5 @@
+package seedu.address.model.role;
+
+public class RoleTest {
+
+}

--- a/src/test/java/seedu/address/model/role/StatusTest.java
+++ b/src/test/java/seedu/address/model/role/StatusTest.java
@@ -1,0 +1,36 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class StatusTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Status(null));
+    }
+
+    @Test
+    public void constructor_invalidStatus_throwsIllegalArgumentException() {
+        String invalidStatus = "";
+        assertThrows(IllegalArgumentException.class, () -> new Status(invalidStatus));
+    }
+
+    @Test
+    public void isValidStatus() {
+        // invalid statuses
+        assertFalse(Status.isValidStatus("")); // empty string
+        assertFalse(Status.isValidStatus(" ")); // spaces only
+        assertFalse(Status.isValidStatus("offering")); // invalid status type
+
+        // valid statuses
+        assertTrue(Status.isValidStatus("applying"));
+        assertTrue(Status.isValidStatus("pending"));
+        assertTrue(Status.isValidStatus("offered"));
+        assertTrue(Status.isValidStatus("rejected"));
+        assertTrue(Status.isValidStatus("complete"));
+    }
+}

--- a/src/test/java/seedu/address/model/role/StipendTest.java
+++ b/src/test/java/seedu/address/model/role/StipendTest.java
@@ -1,0 +1,40 @@
+package seedu.address.model.role;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class StipendTest {
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Stipend(null));
+    }
+
+    @Test
+    public void constructor_invalidStipend_throwsIllegalArgumentException() {
+        String invalidStipend = "";
+        assertThrows(IllegalArgumentException.class, () -> new Stipend(invalidStipend));
+    }
+
+    @Test
+    public void isValidStipend() {
+        // null stipend
+        assertThrows(NullPointerException.class, () -> Stipend.isValidStipend(null));
+
+        // invalid stipends
+        assertFalse(Stipend.isValidStipend("")); // empty string
+        assertFalse(Stipend.isValidStipend(" ")); // spaces only
+        assertFalse(Stipend.isValidStipend("22222222222")); // more than 10 numbers
+        assertFalse(Stipend.isValidStipend("stipend")); // non-numeric
+        assertFalse(Stipend.isValidStipend("22e22")); // alphabets within digits
+        assertFalse(Stipend.isValidStipend("22 22")); // spaces within digits
+
+        // valid stipends
+        assertTrue(Stipend.isValidStipend("1000"));
+        assertTrue(Stipend.isValidStipend("1")); // one number
+        assertTrue(Stipend.isValidStipend("100000000")); // ten numbers
+    }
+}


### PR DESCRIPTION
Closes #45.

A rudimentary `Role` class and relevant tests have been implemented. The implementation is heavily referenced from the `Company` (was `Person`) class. There are however a number of possible improvements to be made:

1. Stipend is currently stored as a string. Could potentially use the Currency library for more appropriate handling.
2. Stipend is displayed numerically as is. May be helpful to abbreviate numbers, e.g. 1200 → 1.2k.
3. Role description is stored as a single string. Would be very helpful to have some kind of Markdown integration.
4. Optional values (description and stipend) are pseudo-optional; they will still technically be stored but as empty strings. Perhaps there could be a better way to handle this?
5. The tests for `RoleTest` have yet to be implemented. Proper testing with roles may take place after implementing some sort of `RoleBuilder` and concretely determining equality check behaviour between `Role` objects.