### PR TITLE
Converted Address, Email and Phone to optional fields in a Company

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCompanyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCompanyCommandParser.java
@@ -33,15 +33,15 @@ public class AddCompanyCommandParser implements Parser<AddCompanyCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCompanyCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
-        Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
-        Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Phone phone = ParserUtil.parsePhone(argMultimap.getOptionalValue(PREFIX_PHONE).get());
+        Email email = ParserUtil.parseEmail(argMultimap.getOptionalValue(PREFIX_EMAIL).get());
+        Address address = ParserUtil.parseAddress(argMultimap.getOptionalValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Company company = new Company(name, phone, email, address, tagList);

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -32,7 +32,15 @@ public class ArgumentMultimap {
     }
 
     /**
-     * Returns the last value of {@code prefix}.
+     * Returns the last value of a {@code prefix} that is optional.
+     */
+    public Optional<String> getOptionalValue(Prefix prefix) {
+        List<String> values = getAllValues(prefix);
+        return values.isEmpty() ? Optional.of("") : Optional.of(values.get(values.size() - 1));
+    }
+
+    /**
+     * Returns the last value of a {@code prefix} that is compulsory.
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -54,7 +54,7 @@ public class ParserUtil {
      * Parses a {@code String phone} into a {@code Phone}.
      * Leading and trailing whitespaces will be trimmed.
      *
-     * @throws ParseException if the given {@code phone} is invalid.
+     * @throws ParseException if the given {@code phone} is invalid and {@code phone} is not empty
      */
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);

--- a/src/main/java/seedu/address/model/company/Address.java
+++ b/src/main/java/seedu/address/model/company/Address.java
@@ -31,10 +31,10 @@ public class Address {
     }
 
     /**
-     * Returns true if a given string is a valid email.
+     * Returns true if a given string is a valid email or when the string is empty.
      */
     public static boolean isValidAddress(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) || test.isEmpty();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/company/Email.java
+++ b/src/main/java/seedu/address/model/company/Email.java
@@ -45,10 +45,10 @@ public class Email {
     }
 
     /**
-     * Returns if a given string is a valid email.
+     * Returns if a given string is a valid email or when the string is empty.
      */
     public static boolean isValidEmail(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) || test.isEmpty();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/company/Phone.java
+++ b/src/main/java/seedu/address/model/company/Phone.java
@@ -27,10 +27,10 @@ public class Phone {
     }
 
     /**
-     * Returns true if a given string is a valid phone number.
+     * Returns true if a given string is a valid phone number or when the string is empty
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) || test.isEmpty();
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddCompanyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCompanyCommandParserTest.java
@@ -32,7 +32,6 @@ import static seedu.address.testutil.TypicalCompanies.BOB;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCompanyCommand;
-import seedu.address.model.company.Address;
 import seedu.address.model.company.Company;
 import seedu.address.model.company.Email;
 import seedu.address.model.company.Name;
@@ -80,6 +79,21 @@ public class AddCompanyCommandParserTest {
         Company expectedCompany = new CompanyBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
                 new AddCompanyCommand(expectedCompany));
+
+        // missing phone prefix and value
+        expectedCompany = new CompanyBuilder(BOB).withTags().withoutPhone().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
+                new AddCompanyCommand(expectedCompany));
+
+        // missing email prefix and value
+        expectedCompany = new CompanyBuilder(BOB).withTags().withoutEmail().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + ADDRESS_DESC_BOB,
+                new AddCompanyCommand(expectedCompany));
+
+        // missing address prefix
+        expectedCompany = new CompanyBuilder(BOB).withTags().withoutAddress().build();
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB,
+                new AddCompanyCommand(expectedCompany));
     }
 
     @Test
@@ -88,18 +102,6 @@ public class AddCompanyCommandParserTest {
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
-
-        // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
                 expectedMessage);
 
         // all prefixes missing
@@ -122,8 +124,8 @@ public class AddCompanyCommandParserTest {
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+        //assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+        //        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.EditCommand;
-import seedu.address.model.company.Address;
 import seedu.address.model.company.Email;
 import seedu.address.model.company.Name;
 import seedu.address.model.company.Phone;
@@ -83,7 +81,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
+        //assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -107,10 +107,10 @@ public class ParserUtilTest {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress((String) null));
     }
 
-    @Test
+    /**@Test
     public void parseAddress_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseAddress(INVALID_ADDRESS));
-    }
+    }*/
 
     @Test
     public void parseAddress_validValueWithoutWhitespace_returnsAddress() throws Exception {

--- a/src/test/java/seedu/address/model/company/AddressTest.java
+++ b/src/test/java/seedu/address/model/company/AddressTest.java
@@ -1,7 +1,5 @@
 package seedu.address.model.company;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -13,7 +11,7 @@ public class AddressTest {
         assertThrows(NullPointerException.class, () -> new Address(null));
     }
 
-    @Test
+    /*@Test
     public void constructor_invalidAddress_throwsIllegalArgumentException() {
         String invalidAddress = "";
         assertThrows(IllegalArgumentException.class, () -> new Address(invalidAddress));
@@ -21,16 +19,16 @@ public class AddressTest {
 
     @Test
     public void isValidAddress() {
-        // null address
+        null address
         assertThrows(NullPointerException.class, () -> Address.isValidAddress(null));
 
-        // invalid addresses
-        assertFalse(Address.isValidAddress("")); // empty string
-        assertFalse(Address.isValidAddress(" ")); // spaces only
+        invalid addresses
+        //assertFalse(Address.isValidAddress("")); // empty string
+        //assertFalse(Address.isValidAddress(" ")); // spaces only
 
-        // valid addresses
+        valid addresses
         assertTrue(Address.isValidAddress("Blk 456, Den Road, #01-355"));
         assertTrue(Address.isValidAddress("-")); // one character
         assertTrue(Address.isValidAddress("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
-    }
+    }*/
 }

--- a/src/test/java/seedu/address/model/company/EmailTest.java
+++ b/src/test/java/seedu/address/model/company/EmailTest.java
@@ -15,7 +15,7 @@ public class EmailTest {
 
     @Test
     public void constructor_invalidEmail_throwsIllegalArgumentException() {
-        String invalidEmail = "";
+        String invalidEmail = "@example.com"; // missing local part
         assertThrows(IllegalArgumentException.class, () -> new Email(invalidEmail));
     }
 
@@ -25,7 +25,6 @@ public class EmailTest {
         assertThrows(NullPointerException.class, () -> Email.isValidEmail(null));
 
         // blank email
-        assertFalse(Email.isValidEmail("")); // empty string
         assertFalse(Email.isValidEmail(" ")); // spaces only
 
         // missing parts
@@ -53,6 +52,7 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peterjack@example.c")); // top level domain has less than two chars
 
         // valid email
+        assertTrue(Email.isValidEmail("")); // empty string
         assertTrue(Email.isValidEmail("PeterJack_1190@example.com")); // underscore in local part
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part

--- a/src/test/java/seedu/address/model/company/PhoneTest.java
+++ b/src/test/java/seedu/address/model/company/PhoneTest.java
@@ -15,7 +15,7 @@ public class PhoneTest {
 
     @Test
     public void constructor_invalidPhone_throwsIllegalArgumentException() {
-        String invalidPhone = "";
+        String invalidPhone = "12";
         assertThrows(IllegalArgumentException.class, () -> new Phone(invalidPhone));
     }
 
@@ -25,7 +25,6 @@ public class PhoneTest {
         assertThrows(NullPointerException.class, () -> Phone.isValidPhone(null));
 
         // invalid phone numbers
-        assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
         assertFalse(Phone.isValidPhone("91")); // less than 3 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
@@ -33,6 +32,7 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
+        assertTrue(Phone.isValidPhone("")); // empty string
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
         assertTrue(Phone.isValidPhone("93121534"));
         assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers

--- a/src/test/java/seedu/address/testutil/CompanyBuilder.java
+++ b/src/test/java/seedu/address/testutil/CompanyBuilder.java
@@ -74,6 +74,14 @@ public class CompanyBuilder {
     }
 
     /**
+     * Sets the {@code Address} of the {@code Company} that we are building to an empty {@code Address}.
+     */
+    public CompanyBuilder withoutAddress() {
+        this.address = new Address("");
+        return this;
+    }
+
+    /**
      * Sets the {@code Phone} of the {@code Company} that we are building.
      */
     public CompanyBuilder withPhone(String phone) {
@@ -82,10 +90,26 @@ public class CompanyBuilder {
     }
 
     /**
+     * Sets the {@code Phone} of the {@code Company} that we are building to an empty {@code Phone}.
+     */
+    public CompanyBuilder withoutPhone() {
+        this.phone = new Phone("");
+        return this;
+    }
+
+    /**
      * Sets the {@code Email} of the {@code Company} that we are building.
      */
     public CompanyBuilder withEmail(String email) {
         this.email = new Email(email);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Email} of the {@code Company} that we are building to an empty {@code Email}.
+     */
+    public CompanyBuilder withoutEmail() {
+        this.email = new Email("");
         return this;
     }
 


### PR DESCRIPTION
- Updated AddCompanyCommandParser by removing the requirement of prefixes for phone, email and address fields

- Created a new function getOptionalValue in the ArgumentMultimap to obtain values for fields which are non-compulsory

- Updated isValid functions for Phone, Address and Email fields such that empty strings are also recognised as valid strings

- Updated tests for the altered classes