### PR TITLE
Update ParserUtilTest to handle parsing of 2 indexes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -20,6 +20,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
+    public static final String MESSAGE_INVALID_DOUBLE_INDEX = "Double indexes are missing.";
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 
     /**
@@ -33,6 +34,23 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses two {@code oneBasedIndex} into an array of {@code Index} of length two and returns it.
+     * Leading and trailing whitespaces will be trimmed.
+     * @throws ParseException if one of the specified indexes is invalid (not non-zero unsigned integer)
+     * or one or both indexes are missing.
+     */
+    public static Index[] parseDoubleIndex(String oneBasedIndexes) throws ParseException {
+        String[] splitTrimmedIndexes = oneBasedIndexes.trim().split("\\s+");
+        if (!(splitTrimmedIndexes.length == 2)) {
+            throw new ParseException(MESSAGE_INVALID_DOUBLE_INDEX);
+        }
+        Index firstIndex = parseIndex(splitTrimmedIndexes[0]);
+        Index secondIndex = parseIndex(splitTrimmedIndexes[1]);
+
+        return new Index[]{firstIndex, secondIndex};
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ROLE;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,6 +14,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.company.Address;
 import seedu.address.model.company.Email;
@@ -54,6 +56,26 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_COMPANY, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void parseDoubleIndex_invalidInput_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDoubleIndex("10"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDoubleIndex("10 a"));
+        assertThrows(ParseException.class, () -> ParserUtil.parseDoubleIndex("1 1 1"));
+    }
+
+    @Test
+    public void parseDoubleIndex_validInput_success() throws Exception {
+        // No whitespaces
+        Index[] indexesInput = ParserUtil.parseDoubleIndex("1 1");
+        assertEquals(INDEX_FIRST_COMPANY, indexesInput[0]);
+        assertEquals(INDEX_FIRST_ROLE, indexesInput[1]);
+
+        // Leading and trailing whitespaces
+        Index[] indexesWhiteSpaceInput = ParserUtil.parseDoubleIndex("  1     1  ");
+        assertEquals(INDEX_FIRST_COMPANY, indexesWhiteSpaceInput[0]);
+        assertEquals(INDEX_FIRST_ROLE, indexesWhiteSpaceInput[1]);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_COMPANY = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_COMPANY = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_COMPANY = Index.fromOneBased(3);
+    public static final Index INDEX_FIRST_ROLE = Index.fromOneBased(1);
 }


### PR DESCRIPTION
Update parseDoubleIndex for the ease of handling parsing 2 indexes mainly for addRole and deleteRole.

1. parseDoubleIndex will return an array of length 2 with 2 one based index.

2. Update testing for parseDoubleIndex.