### PR TITLE
Fix company display Ui

### DIFF
--- a/src/main/java/seedu/address/ui/CompanyCard.java
+++ b/src/main/java/seedu/address/ui/CompanyCard.java
@@ -49,9 +49,25 @@ public class CompanyCard extends UiPart<Region> {
         this.company = company;
         id.setText(displayedIndex + ". ");
         name.setText(company.getName().fullName);
-        phone.setText(company.getPhone().value);
-        address.setText(company.getAddress().value);
-        email.setText(company.getEmail().value);
+
+        String phoneField = company.getPhone().value;
+        String addressField = company.getAddress().value;
+        String emailField = company.getEmail().value;
+
+        phone.setText(phoneField);
+        address.setText(addressField);
+        email.setText(emailField);
+
+        if (phoneField == "") {
+            phone.setManaged(false);
+        }
+        if (addressField == "") {
+            address.setManaged(false);
+        }
+        if (emailField == "") {
+            email.setManaged(false);
+        }
+
         company.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));


### PR DESCRIPTION
1. If there are missing optional fields, disable the fields in the UI to prevent gaps between the fields.

![image](https://user-images.githubusercontent.com/66625773/156155737-433f6c03-e6a1-4c54-a347-5978b384605c.png)
Remove gaps between the fields

Suggestion for improvement by others:
1. Include label name, e.g. name: , phone: etc for readability.
2. Instead of centralising the fields, push the fields to the top. 