### PR TITLE
Fix storage behaviour with find command

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -125,9 +125,10 @@ public class ModelManager implements Model {
 
     @Override
     public void updateFilteredCompanyList(Predicate<Company> companyPredicate, Predicate<Role> rolePredicate) {
-        requireNonNull(companyPredicate);
-        filteredCompanies.setPredicate(companyPredicate);
+        requireAllNonNull(companyPredicate, rolePredicate);
+        filteredCompanies.setPredicate(PREDICATE_SHOW_ALL_COMPANIES);
         filteredCompanies.forEach(company -> company.getRoleManager().updateFilteredRoleList(rolePredicate));
+        filteredCompanies.setPredicate(companyPredicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/company/CompanyNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/company/CompanyNameContainsKeywordsPredicate.java
@@ -36,8 +36,12 @@ public class CompanyNameContainsKeywordsPredicate implements Predicate<Company> 
 
     @Override
     public boolean test(Company company) {
-        return companyNameKeywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(company.getName().fullName, keyword));
+        if (!companyNameKeywords.isEmpty()) {
+            return companyNameKeywords.stream()
+                    .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(company.getName().fullName, keyword));
+        }
+        // r/ must exist at this point in find command
+        return !company.getRoleManager().getFilteredRoleList().isEmpty();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/company/ReadOnlyRoleList.java
+++ b/src/main/java/seedu/address/model/company/ReadOnlyRoleList.java
@@ -12,6 +12,6 @@ public interface ReadOnlyRoleList {
      * Returns an unmodifiable view of the roles list.
      * This list will not contain any duplicate roles.
      */
-    ObservableList<Role> getRoleList();
+    ObservableList<Role> getRoles();
 
 }

--- a/src/main/java/seedu/address/model/company/RoleList.java
+++ b/src/main/java/seedu/address/model/company/RoleList.java
@@ -55,7 +55,7 @@ public class RoleList implements ReadOnlyRoleList {
     public void resetData(ReadOnlyRoleList newData) {
         requireNonNull(newData);
 
-        setRoles(newData.getRoleList());
+        setRoles(newData.getRoles());
     }
 
     //// company-level operations
@@ -105,7 +105,7 @@ public class RoleList implements ReadOnlyRoleList {
     }
 
     @Override
-    public ObservableList<Role> getRoleList() {
+    public ObservableList<Role> getRoles() {
         return roles.asUnmodifiableObservableList();
     }
 

--- a/src/main/java/seedu/address/model/company/RoleManager.java
+++ b/src/main/java/seedu/address/model/company/RoleManager.java
@@ -29,7 +29,7 @@ public class RoleManager {
         requireAllNonNull(roleList);
 
         this.roleList = new RoleList(roleList);
-        this.filteredRoles = new FilteredList<>(this.roleList.getRoleList());
+        this.filteredRoles = new FilteredList<>(this.roleList.getRoles());
     }
 
     public RoleManager() {

--- a/src/main/java/seedu/address/model/company/RoleManager.java
+++ b/src/main/java/seedu/address/model/company/RoleManager.java
@@ -100,6 +100,7 @@ public class RoleManager {
      */
     public void updateFilteredRoleList(Predicate<Role> predicate) {
         requireNonNull(predicate);
+        filteredRoles.setPredicate(PREDICATE_SHOW_ALL_ROLES);
         filteredRoles.setPredicate(predicate);
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedCompany.java
@@ -63,7 +63,8 @@ class JsonAdaptedCompany {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        roles.addAll(source.getRoleManager().getFilteredRoleList().stream()
+        roles.addAll(source.getRoleManager().getRoleList()
+                .getRoles().stream()
                 .map(JsonAdaptedRole::new)
                 .collect(Collectors.toList()));
     }

--- a/src/main/java/seedu/address/storage/JsonSerializableRoleList.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableRoleList.java
@@ -37,7 +37,7 @@ class JsonSerializableRoleList {
      * @param source future changes to this will not affect the created {@code JsonSerializableRoleList}.
      */
     public JsonSerializableRoleList(ReadOnlyRoleList source) {
-        roles.addAll(source.getRoleList().stream().map(JsonAdaptedRole::new).collect(Collectors.toList()));
+        roles.addAll(source.getRoles().stream().map(JsonAdaptedRole::new).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_COMPANIES_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.model.company.RoleManager.PREDICATE_SHOW_ALL_ROLES;
 import static seedu.address.testutil.TypicalCompanies.APPLE;
 import static seedu.address.testutil.TypicalCompanies.GOVTECH;
 import static seedu.address.testutil.TypicalCompanies.ZOOM;
@@ -58,17 +57,6 @@ public class FindCommandTest {
 
         // different company -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
-    }
-
-    @Test
-    public void execute_zeroKeywords_noCompanyFound() {
-        String expectedMessage = String.format(MESSAGE_COMPANIES_LISTED_OVERVIEW, 0);
-        CompanyNameContainsKeywordsPredicate companyPredicate = prepareCompanyPredicate(" ");
-        RoleNameContainsKeywordsPredicate rolePredicate = prepareRolePredicate(" ");
-        FindCommand command = new FindCommand(companyPredicate, rolePredicate);
-        expectedModel.updateFilteredCompanyList(companyPredicate, PREDICATE_SHOW_ALL_ROLES);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredCompanyList());
     }
 
     @Test


### PR DESCRIPTION
Closes #113.

Updates `JsonAdaptedCompany` such that the internal role list is used for storage rather than the filtered role list.