### PR TITLE
Create editRole command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditRoleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditRoleCommand.java
@@ -1,0 +1,215 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STIPEND;
+import static seedu.address.model.company.RoleManager.PREDICATE_SHOW_ALL_ROLES;
+
+import java.util.List;
+import java.util.Optional;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.company.Company;
+import seedu.address.model.company.RoleManager;
+import seedu.address.model.role.Deadline;
+import seedu.address.model.role.Description;
+import seedu.address.model.role.Role;
+import seedu.address.model.role.RoleName;
+import seedu.address.model.role.Status;
+import seedu.address.model.role.Stipend;
+
+
+/**
+ * Edits the details of an existing role in an existing company.
+ */
+public class EditRoleCommand extends Command {
+    public static final String COMMAND_WORD = "editRole";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the Role"
+            + " identified "
+            + "by the index number of the company used in the displayed company list.\n"
+            + "Followed by the index number used by the role in the specified company.\n"
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: COMPANY_INDEX ROLE_INDEX (both must be positive integers) "
+            + "[" + PREFIX_NAME + "ROLENAME] "
+            + "[" + PREFIX_STATUS + "STATUS] "
+            + "[" + PREFIX_DEADLINE + "DEADLINE] "
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_STIPEND + "STIPEND]...\n"
+            + "Example: " + COMMAND_WORD + " 1 1 "
+            + PREFIX_STATUS + "PENDING "
+            + PREFIX_STIPEND + "3000";
+
+    public static final String MESSAGE_EDIT_ROLE_SUCCESS = "Edited Role: %1$s %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_ROLE = "This role already exists in the "
+            + "company.";
+
+    private final Index companyIndex;
+    private final Index roleIndex;
+
+    private final EditRoleDescriptor editRoleDescriptor;
+
+    /**
+     * @param companyIndex       of the company in the filtered company list to edit
+     * @param roleIndex          of the role in the company in the filtered company list to edit
+     * @param editRoleDescriptor details to edit the company with
+     */
+    public EditRoleCommand(Index companyIndex, Index roleIndex, EditRoleDescriptor editRoleDescriptor) {
+        requireAllNonNull(companyIndex, roleIndex, editRoleDescriptor);
+
+        this.companyIndex = companyIndex;
+        this.roleIndex = roleIndex;
+        this.editRoleDescriptor = editRoleDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ObservableList<Company> lastShownCompanyList = model.getFilteredCompanyList();
+
+        if (companyIndex.getZeroBased() >= lastShownCompanyList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+        }
+
+        Company companyTarget = lastShownCompanyList.get(companyIndex.getZeroBased());
+        RoleManager roleManager = companyTarget.getRoleManager();
+        List<Role> lastShownRoleList = roleManager.getFilteredRoleList();
+
+        if (roleIndex.getZeroBased() >= lastShownRoleList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ROLE_DISPLAYED_INDEX);
+        }
+
+        Role roleToEdit = lastShownRoleList.get(roleIndex.getZeroBased());
+        Role editedRole = createEditedRole(roleToEdit, editRoleDescriptor);
+
+        if (!roleToEdit.isSameRole(editedRole) && roleManager.hasRole(editedRole)) {
+            throw new CommandException(MESSAGE_DUPLICATE_ROLE);
+        }
+
+        roleManager.setRole(roleToEdit, editedRole);
+        roleManager.updateFilteredRoleList(PREDICATE_SHOW_ALL_ROLES);
+
+        return new CommandResult(String.format(MESSAGE_EDIT_ROLE_SUCCESS, editedRole));
+    }
+
+    /**
+     * Creates and returns a {@code Role} with the details of {@code roleToEdit}
+     * edited with {@code editRoleDescriptor}.
+     */
+    private static Role createEditedRole(Role roleToEdit,
+                                               EditRoleCommand.EditRoleDescriptor editRoleDescriptor) {
+        assert roleToEdit != null;
+
+        RoleName updatedName = editRoleDescriptor.getName().orElse(roleToEdit.getName());
+        Status updatedStatus = editRoleDescriptor.getStatus().orElse(roleToEdit.getStatus());
+        Deadline updatedDeadline = editRoleDescriptor.getDeadline().orElse(roleToEdit.getDeadline());
+        Description updatedDescription =
+                editRoleDescriptor.getDescription().orElse(roleToEdit.getDescription());
+        Stipend updatedStipend = editRoleDescriptor.getStipend().orElse(roleToEdit.getStipend());
+
+        return new Role(updatedName, updatedStatus, updatedDeadline, updatedDescription, updatedStipend);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EditRoleCommand // instanceof handles nulls
+                && companyIndex.equals(((EditRoleCommand) other).companyIndex)) // state check
+                && roleIndex.equals(((EditRoleCommand) other).roleIndex)
+                && editRoleDescriptor.equals(((EditRoleCommand) other).editRoleDescriptor);
+    }
+
+    /**
+     * Stores the details to edit the Role with. Each non-empty field value will replace the
+     * corresponding field value of the Role.
+     */
+    public static class EditRoleDescriptor {
+        private RoleName name;
+        private Status status;
+        private Deadline deadline;
+        private Description description;
+        private Stipend stipend;
+
+        public EditRoleDescriptor() {
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, status, deadline, description, stipend);
+        }
+
+        public void setName(RoleName name) {
+            this.name = name;
+        }
+
+        public Optional<RoleName> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setStatus(Status status) {
+            this.status = status;
+        }
+
+        public Optional<Status> getStatus() {
+            return Optional.ofNullable(status);
+        }
+
+        public void setDeadline(Deadline deadline) {
+            this.deadline = deadline;
+        }
+
+        public Optional<Deadline> getDeadline() {
+            return Optional.ofNullable(deadline);
+        }
+
+        public void setDescription(Description description) {
+            this.description = description;
+        }
+
+        public Optional<Description> getDescription() {
+            return Optional.ofNullable(description);
+        }
+
+        public void setStipend(Stipend stipend) {
+            this.stipend = stipend;
+        }
+
+        public Optional<Stipend> getStipend() {
+            return Optional.ofNullable(stipend);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditRoleCommand.EditRoleDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditRoleCommand.EditRoleDescriptor e = (EditRoleCommand.EditRoleDescriptor) other;
+
+            return getName().equals(e.getName())
+                    && getStatus().equals(e.getStatus())
+                    && getDeadline().equals(e.getDeadline())
+                    && getDescription().equals(e.getDescription())
+                    && getStipend().equals(e.getStipend());
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCompanyCommand;
 import seedu.address.logic.commands.DeleteRoleCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditRoleCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -75,6 +76,9 @@ public class AddressBookParser {
 
         case DeleteRoleCommand.COMMAND_WORD:
             return new DeleteRoleCommandParser().parse(arguments);
+
+        case EditRoleCommand.COMMAND_WORD:
+            return new EditRoleCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/EditRoleCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditRoleCommandParser.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STIPEND;
+
+import javafx.util.Pair;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditRoleCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditRoleCommand object
+ */
+public class EditRoleCommandParser implements Parser<EditRoleCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditRoleCommand
+     * and returns an EditRoleCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditRoleCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        Pair<Index[], String> parsedInput;
+
+        try {
+            parsedInput = ParserUtil.parseDoubleIndexWithContent(args);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditRoleCommand.MESSAGE_USAGE), pe);
+        }
+
+        Index[] indexes = parsedInput.getKey();
+        Index companyIndex = indexes[0];
+        Index roleIndex = indexes[1];
+        String content = parsedInput.getValue();
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(content, PREFIX_NAME, PREFIX_STATUS,
+                        PREFIX_DEADLINE, PREFIX_DESCRIPTION, PREFIX_STIPEND);
+
+        EditRoleCommand.EditRoleDescriptor editRoleDescriptor = new EditRoleCommand.EditRoleDescriptor();
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editRoleDescriptor.setName(ParserUtil.parseRoleName(argMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            editRoleDescriptor.setStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DEADLINE).isPresent()) {
+            editRoleDescriptor.setDeadline(ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+            editRoleDescriptor.setDescription(ParserUtil.parseDescription(argMultimap
+                    .getValue(PREFIX_DESCRIPTION).get()));
+        }
+        if (argMultimap.getValue(PREFIX_STIPEND).isPresent()) {
+            editRoleDescriptor.setStipend(ParserUtil.parseStipend(argMultimap.getValue(PREFIX_STIPEND).get()));
+        }
+        if (!editRoleDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditRoleCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new EditRoleCommand(companyIndex, roleIndex, editRoleDescriptor);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -55,7 +55,7 @@ public class ParserUtil {
      */
     public static Index[] parseDoubleIndex(String oneBasedIndexes) throws ParseException {
         String[] splitTrimmedIndexes = oneBasedIndexes.trim().split("\\s+");
-        if (!(splitTrimmedIndexes.length == 2)) {
+        if (splitTrimmedIndexes.length != 2) {
             throw new ParseException(MESSAGE_INVALID_DOUBLE_INDEX);
         }
         Index firstIndex = parseIndex(splitTrimmedIndexes[0]);
@@ -73,7 +73,7 @@ public class ParserUtil {
      */
     public static Pair<Index, String> parseIndexWithContent(String content) throws ParseException {
         String[] splitTrimmedContent = content.trim().split("\\s+", 2);
-        if (!(splitTrimmedContent.length == 2)) {
+        if (splitTrimmedContent.length != 2) {
             throw new ParseException(MESSAGE_INVALID_CONTENT);
         }
         Index index = parseIndex(splitTrimmedContent[0]);
@@ -90,7 +90,7 @@ public class ParserUtil {
      */
     public static Pair<Index[], String> parseDoubleIndexWithContent(String content) throws ParseException {
         String[] splitTrimmedContent = content.trim().split("\\s+", 3);
-        if (!(splitTrimmedContent.length == 3)) {
+        if (splitTrimmedContent.length != 3) {
             throw new ParseException(MESSAGE_INVALID_CONTENT);
         }
         Index[] indexes = parseDoubleIndex(splitTrimmedContent[0] + " "

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -28,6 +28,7 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_DOUBLE_INDEX = "Double indexes are missing.";
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_CONTENT = "Index[es] and/or content are missing.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing
@@ -64,7 +65,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses two {@code oneBasedIndex} into an array of {@code Index} of length two and returns it.
+     * Parses  {@code oneBasedIndex} and content into an {@code Index} and string.
      *
      * @param content String representation of user input.
      * @return Pair containing company index and role information.
@@ -73,11 +74,29 @@ public class ParserUtil {
     public static Pair<Index, String> parseIndexWithContent(String content) throws ParseException {
         String[] splitTrimmedContent = content.trim().split("\\s+", 2);
         if (!(splitTrimmedContent.length == 2)) {
-            throw new ParseException(MESSAGE_INVALID_DOUBLE_INDEX);
+            throw new ParseException(MESSAGE_INVALID_CONTENT);
         }
         Index index = parseIndex(splitTrimmedContent[0]);
         String info = " " + splitTrimmedContent[1];
         return new Pair<>(index, info);
+    }
+
+    /**
+     * Parses two {@code oneBasedIndex} and content into an array of {@code Index} and string.
+     *
+     * @param content String representation of user input.
+     * @return Pair containing company index, role index and role information.
+     * @throws ParseException if either index or role information is absent or index is invalide.
+     */
+    public static Pair<Index[], String> parseDoubleIndexWithContent(String content) throws ParseException {
+        String[] splitTrimmedContent = content.trim().split("\\s+", 3);
+        if (!(splitTrimmedContent.length == 3)) {
+            throw new ParseException(MESSAGE_INVALID_CONTENT);
+        }
+        Index[] indexes = parseDoubleIndex(splitTrimmedContent[0] + " "
+                + splitTrimmedContent[1]);
+        String info = " " + splitTrimmedContent[2];
+        return new Pair<>(indexes, info);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditRoleCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditRoleCommandTest.java
@@ -1,0 +1,75 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_WHATSAPP;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATUS_SOFTWARE_ENGINEER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STIPEND_SOFTWARE_ENGINEER;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalCompanies.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ROLE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.CompanyList;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.company.Company;
+import seedu.address.model.company.RoleManager;
+import seedu.address.model.role.Role;
+import seedu.address.testutil.EditRoleDescriptorBuilder;
+import seedu.address.testutil.RoleBuilder;
+
+public class EditRoleCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedList_success() {
+        Role editedRole = new RoleBuilder().build();
+        EditRoleCommand.EditRoleDescriptor descriptor = new EditRoleDescriptorBuilder(editedRole).build();
+        EditRoleCommand editRoleCommand = new EditRoleCommand(INDEX_FIRST_COMPANY, INDEX_FIRST_ROLE,
+                descriptor);
+        String expectedMessage = String.format(EditRoleCommand.MESSAGE_EDIT_ROLE_SUCCESS, editedRole);
+
+        Model expectedModel = new ModelManager(new CompanyList(model.getCompanyList()), new UserPrefs());
+        RoleManager expectedRM = expectedModel.getFilteredCompanyList().get(INDEX_FIRST_COMPANY.getZeroBased())
+                .getRoleManager();
+        Role expectedRole = expectedRM.getFilteredRoleList().get(INDEX_FIRST_ROLE.getZeroBased());
+        expectedRM.setRole(expectedRole, editedRole);
+
+        assertCommandSuccess(editRoleCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecified_success() {
+        Index indexLastCompany = Index.fromOneBased(model.getFilteredCompanyList().size());
+        Company lastCompany = model.getFilteredCompanyList().get(indexLastCompany.getZeroBased());
+
+        RoleManager roleManager = lastCompany.getRoleManager();
+        Index indexLastRole = Index.fromOneBased(roleManager.getFilteredRoleList().size());
+        Role lastRole = roleManager.getFilteredRoleList().get(indexLastRole.getZeroBased());
+
+        RoleBuilder roleInList = new RoleBuilder(lastRole);
+        Role editedRole = roleInList.withName(VALID_NAME_WHATSAPP)
+                .withStatus(VALID_STATUS_SOFTWARE_ENGINEER).withStipend(VALID_STIPEND_SOFTWARE_ENGINEER)
+                .build();
+
+        EditRoleCommand.EditRoleDescriptor descriptor = new EditRoleDescriptorBuilder().withName(VALID_NAME_WHATSAPP)
+                .withStatus(VALID_STATUS_SOFTWARE_ENGINEER).withStipend(VALID_STIPEND_SOFTWARE_ENGINEER).build();
+
+        EditRoleCommand editRoleCommand = new EditRoleCommand(indexLastCompany, indexLastRole, descriptor);
+
+        String expectedMessage = String.format(EditRoleCommand.MESSAGE_EDIT_ROLE_SUCCESS, editedRole);
+
+        Model expectedModel = new ModelManager(new CompanyList(model.getCompanyList()), new UserPrefs());
+        RoleManager expectedRM = expectedModel.getFilteredCompanyList().get(indexLastCompany.getZeroBased())
+                .getRoleManager();
+        expectedRM.setRole(lastRole, editedRole);
+
+        assertCommandSuccess(editRoleCommand, model, expectedMessage, expectedModel);
+    }
+
+
+
+}

--- a/src/test/java/seedu/address/testutil/EditRoleDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditRoleDescriptorBuilder.java
@@ -1,0 +1,81 @@
+package seedu.address.testutil;
+
+import seedu.address.logic.commands.EditRoleCommand;
+import seedu.address.model.role.Deadline;
+import seedu.address.model.role.Description;
+import seedu.address.model.role.Role;
+import seedu.address.model.role.RoleName;
+import seedu.address.model.role.Status;
+import seedu.address.model.role.Stipend;
+
+/**
+ * A utility class to help with building EditRoleDescriptor objects.
+ */
+public class EditRoleDescriptorBuilder {
+    private EditRoleCommand.EditRoleDescriptor descriptor;
+
+
+    public EditRoleDescriptorBuilder() {
+        this.descriptor = new EditRoleCommand.EditRoleDescriptor();
+    }
+
+    public EditRoleDescriptorBuilder(EditRoleCommand.EditRoleDescriptor descriptor) {
+        this.descriptor = descriptor;
+    }
+
+    /**
+     * Returns an {@code EditRoleDescriptor} with fields containing {@code Role}'s details
+     */
+    public EditRoleDescriptorBuilder(Role role) {
+        descriptor = new EditRoleCommand.EditRoleDescriptor();
+        descriptor.setName(role.getName());
+        descriptor.setStatus(role.getStatus());
+        descriptor.setDeadline(role.getDeadline());
+        descriptor.setDescription(role.getDescription());
+        descriptor.setStipend(role.getStipend());
+    }
+
+    /**
+     * Sets the {@code Name} of the {@code EditRoleDescriptor} that we are building.
+     */
+    public EditRoleDescriptorBuilder withName(String name) {
+        descriptor.setName(new RoleName(name));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Status} of the {@code EditRoleDescriptor} that we are building.
+     */
+    public EditRoleDescriptorBuilder withStatus(String status) {
+        descriptor.setStatus(new Status(status));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Deadline} of the {@code EditRoleDescriptor} that we are building.
+     */
+    public EditRoleDescriptorBuilder withDeadline(String deadline) {
+        descriptor.setDeadline(new Deadline(deadline));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Description} of the {@code EditRoleDescriptor} that we are building.
+     */
+    public EditRoleDescriptorBuilder withDescription(String description) {
+        descriptor.setDescription(new Description(description));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Stipend} of the {@code EditRoleDescriptor} that we are building.
+     */
+    public EditRoleDescriptorBuilder withStipend(String stipend) {
+        descriptor.setStipend(new Stipend(stipend));
+        return this;
+    }
+
+    public EditRoleCommand.EditRoleDescriptor build() {
+        return descriptor;
+    }
+}


### PR DESCRIPTION
Handle editing of a role in a filtered and unfiltered company list

1. EditRoleCommand class to handle the command and execution of editing role

2. EditRoleCommandParser class to handle the input from the user

3. ParserUtil.parseDoubleIndexWithContent method to handle two indexes and role information from the user's input

4. EditRoleDescriptionBuilder class to assist in testing EditRoleCommand

5. Fix checkstyle error

To do next:
1. continue testing for the command class
2. Testing for parser class
3. Testing for parseDoubleIndexWithContent method