### PR TITLE
Implement updated parser logic to disallow empty strings or white spaces after a prefix

### DIFF
--- a/src/main/java/seedu/tinner/commons/core/Messages.java
+++ b/src/main/java/seedu/tinner/commons/core/Messages.java
@@ -10,6 +10,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX = "The company index provided is invalid";
     public static final String MESSAGE_COMPANIES_LISTED_OVERVIEW = "%1$d companies listed!";
     public static final String MESSAGE_INVALID_ROLE_DISPLAYED_INDEX = "The role index provided is invalid";
+    public static final String MESSAGE_NO_VALUE_AFTER_PREFIX = "Invalid command format! There must be a value "
+            + "after a prefix. \n%1$s";
 
 }
 

--- a/src/main/java/seedu/tinner/logic/parser/AddCompanyCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/AddCompanyCommandParser.java
@@ -1,12 +1,11 @@
 package seedu.tinner.logic.parser;
 
 import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.tinner.commons.core.Messages.MESSAGE_NO_VALUE_AFTER_PREFIX;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_PHONE;
-
-import java.util.stream.Stream;
 
 import seedu.tinner.logic.commands.AddCompanyCommand;
 import seedu.tinner.logic.parser.exceptions.ParseException;
@@ -33,9 +32,17 @@ public class AddCompanyCommandParser implements Parser<AddCompanyCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_NAME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddCompanyCommand.MESSAGE_USAGE));
+        }
+
+        if (ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_NAME)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_PHONE)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_EMAIL)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_ADDRESS)) {
+            throw new ParseException(String.format(MESSAGE_NO_VALUE_AFTER_PREFIX,
                     AddCompanyCommand.MESSAGE_USAGE));
         }
 
@@ -43,19 +50,11 @@ public class AddCompanyCommandParser implements Parser<AddCompanyCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getOptionalValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getOptionalValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getOptionalValue(PREFIX_ADDRESS).get());
-        RoleList roles = new RoleList(); // Dummy placeholder, will update in v1.2b
+        RoleList roles = new RoleList();
 
         Company company = new Company(name, phone, email, address, roles);
 
         return new AddCompanyCommand(company);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/tinner/logic/parser/AddRoleCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/AddRoleCommandParser.java
@@ -1,13 +1,13 @@
 package seedu.tinner.logic.parser;
 
 import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.tinner.commons.core.Messages.MESSAGE_NO_VALUE_AFTER_PREFIX;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_STIPEND;
-
-import java.util.stream.Stream;
+import static seedu.tinner.logic.parser.ParserUtil.arePrefixesPresent;
 
 import javafx.util.Pair;
 import seedu.tinner.commons.core.index.Index;
@@ -48,6 +48,16 @@ public class AddRoleCommandParser implements Parser<AddRoleCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRoleCommand.MESSAGE_USAGE));
         }
+
+        if (ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_NAME)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_STATUS)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_DEADLINE)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_DESCRIPTION)
+                || ParserUtil.hasPrefixWithoutValue(argMultimap, PREFIX_STIPEND)) {
+            throw new ParseException(String.format(MESSAGE_NO_VALUE_AFTER_PREFIX,
+                    AddRoleCommand.MESSAGE_USAGE));
+        }
+
         RoleName name = ParserUtil.parseRoleName(argMultimap.getValue(PREFIX_NAME).get());
         Status status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
         Deadline deadline = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_DEADLINE).get());
@@ -55,14 +65,6 @@ public class AddRoleCommandParser implements Parser<AddRoleCommand> {
         Stipend stipend = ParserUtil.parseStipend(argMultimap.getOptionalValue(PREFIX_STIPEND).get());
         Role role = new Role(name, status, deadline, description, stipend);
         return new AddRoleCommand(index, role);
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 
 }

--- a/src/main/java/seedu/tinner/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/FindCommandParser.java
@@ -3,9 +3,9 @@ package seedu.tinner.logic.parser;
 import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_COMPANY_NAME;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_ROLE_NAME;
+import static seedu.tinner.logic.parser.ParserUtil.arePrefixesPresent;
 
 import java.util.Arrays;
-import java.util.stream.Stream;
 
 import seedu.tinner.logic.commands.FindCommand;
 import seedu.tinner.logic.parser.exceptions.ParseException;
@@ -59,11 +59,4 @@ public class FindCommandParser implements Parser<FindCommand> {
                 new RoleNameContainsKeywordsPredicate(Arrays.asList(roleNameKeywords)));
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/seedu/tinner/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/tinner/logic/parser/ParserUtil.java
@@ -2,6 +2,8 @@ package seedu.tinner.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.stream.Stream;
+
 import javafx.util.Pair;
 import seedu.tinner.commons.core.index.Index;
 import seedu.tinner.commons.util.StringUtil;
@@ -227,5 +229,22 @@ public class ParserUtil {
             throw new ParseException(Stipend.MESSAGE_CONSTRAINTS);
         }
         return new Stipend(trimmedStipend);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Returns true if prefix is found and the corresponding prefix contains empty values in the given
+     * {@code ArgumentMultimap}.
+     */
+    public static boolean hasPrefixWithoutValue(ArgumentMultimap argumentMultimap, Prefix prefix) {
+        return (arePrefixesPresent(argumentMultimap, prefix)
+                && argumentMultimap.getOptionalValue(prefix).get().isEmpty());
     }
 }

--- a/src/test/java/seedu/tinner/logic/parser/AddCompanyCommandParserTest.java
+++ b/src/test/java/seedu/tinner/logic/parser/AddCompanyCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.tinner.logic.commands.CommandTestUtil.ADDRESS_DESC_INSTAGRAM
 import static seedu.tinner.logic.commands.CommandTestUtil.ADDRESS_DESC_WHATSAPP;
 import static seedu.tinner.logic.commands.CommandTestUtil.EMAIL_DESC_INSTAGRAM;
 import static seedu.tinner.logic.commands.CommandTestUtil.EMAIL_DESC_WHATSAPP;
-import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -134,7 +133,7 @@ public class AddCompanyCommandParserTest {
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_WHATSAPP
-                        + EMAIL_DESC_WHATSAPP + INVALID_ADDRESS_DESC,
+                        + EMAIL_DESC_WHATSAPP,
                 CompanyName.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble


### PR DESCRIPTION
- Move arePrefixesPresent method to ParserUtil, from specific Command Parser Classes to reduce code duplication

- Create hasPrefixWithoutValue method in ParserUtil class to check for empty values after prefix

- New message to warn users of empty values after prefix

- Throw Parser exception in the event where the prefix is present with and empty value (or blank spaces)

- In AddRoleCommandParser and AddCompanyCommandParser, enforce that there are no prefixes present with empty corresponding values