### PR TITLE
Implement favourite, unfavourite and listFavourite commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -11,11 +11,14 @@ Tinner (Anagram of Intern) is a desktop app for managing internship applications
 * [Features](#features)
 * [Viewing help: `help`](#c-help)
 * [Viewing all companies and roles: `list`](#c-list)
+* [Viewing all favourited companies: `listFavourite`](#c-listfavourite)
 * [Adding a company: `addCompany`](#c-add-c)
 * [Adding a role: `addRole`](#c-add-c-r)
 * [Deleting a company: `deleteCompany`](#c-delete-c)
 * [Deleting a role: `deleteRole`](#c-delete-c-r)
 * [Finding a specific company or role: `find`](#c-find-c-r)
+* [Favouriting a specific company: `favourite`](#c-favourite-c)  
+* [Unfavouriting a specific company: `unfavourite`](#c-unfavourite-c)
 * [Command summary](#command-summary)
 
 --------------------------------------------------------------------------------------------------------------------
@@ -81,6 +84,12 @@ Format: `help`
 Shows a list of all companies and internship roles in Tinner.
 
 Format: `list`
+
+### Listing all favourited companies : `listFavourite` <a id="c-listfavourite"></a>
+
+Shows a list of all favourited companies and internship roles within these companies in Tinner.
+
+Format: `listFavourite`
 
 ### Adding a company: `addCompany` <a id="c-add-c"></a>
 
@@ -153,6 +162,36 @@ Examples:
 
 * `find c/meta amazon r/engineer` 
 
+### Favouriting a specific company: `favourite` <a id="c-favourite-c"></a>
+
+Favourite a specific company from the list of companies
+
+Format: `favourite COMPANY_INDEX`
+
+* Favourites the company at the specified `COMPANY_INDEX`.
+* The index refer to the index number shown in the displayed company list.
+* The indexes must be a positive integer like 1, 2, 3, …
+
+Examples:
+
+* `list` followed by, `favourite 1` favourites the 1<sup>st</sup>
+  company in Tinner.
+
+### Unfavouriting a specific company: `unfavourite` <a id="c-unfavourite-c"></a>
+
+Unfavourite a specific company from the list of companies
+
+Format: `unfavourite COMPANY_INDEX`
+
+* Unfavourites the company at the specified `COMPANY_INDEX`.
+* The index refer to the index number shown in the displayed company list.
+* The indexes must be a positive integer like 1, 2, 3, …
+
+Examples:
+
+* `list` followed by, `unfavourite 1` unfavourites the 1<sup>st</sup>
+  company in Tinner.
+  
 ### Exiting the program : `exit` <a id="c-exit"></a>
 
 Exits the program.
@@ -174,10 +213,13 @@ _Details coming soon ..._
 Action | Format, Examples
 --------|------------------
 **List companies** | `list`
+**List favourited companies** | `listFavourite`
 **Add company** | `addCompany n/COMPANY_NAME [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS]` <br><br> e.g.,`addCompany n/Google p/98765432 e/hr_google@gmail.com a/70 Pasir Panjang Rd, #03-71 Mapletree Business City II, Singapore 117371`
 **Add role** | `addRole COMPANY_INDEX n/ROLE s/STATUS b/DEADLINE d/DESCRIPTION $/STIPEND` <br><br> e.g.,` addRole 1 n/Data Analyst s/Applying b/31 March 2022 23:59 d/Analyse marketing data $/5000`
 **Delete company** | `deleteCompany COMPANY_INDEX `<br><br> e.g.,`deleteCompany 3 `
 **Delete role** | `deleteRole COMPANY_INDEX ROLE_INDEX` <br><br> e.g.,`deleteRole 3 1 `
 **Find company or role** | `find c/COMPANY_KEYWORD [MORE_COMPANY_KEYWORDS] r/ROLE_KEYWORD [MORE_ROLE_KEYWORDS]` <br><br> e.g., `find c/google r/mobile software`
+**Favourite company** | `favourite COMPANY_INDEX`
+**Unfavourite company** | `unfavourite COMPANY_INDEX`
 **Help** | `help`
 **Exit Tinner** | `exit`

--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -346,7 +346,7 @@ save it with `Model#setCompany()`.
         Company companyToEdit = lastShownList.get(index.getZeroBased());
         Company editedCompany = new Company(
                 companyToEdit.getName(), companyToEdit.getPhone(), companyToEdit.getEmail(),
-                companyToEdit.getAddress(), remark, companyToEdit.getTags());
+                companyToEdit.getAddress(), companyToEdit.getRoles(), companyToEdit.getFavouriteStatus());
 
         model.setCompany(companyToEdit, editedCompany);
         model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES);

--- a/src/main/java/seedu/tinner/logic/commands/EditCompanyCommand.java
+++ b/src/main/java/seedu/tinner/logic/commands/EditCompanyCommand.java
@@ -20,6 +20,7 @@ import seedu.tinner.model.company.Address;
 import seedu.tinner.model.company.Company;
 import seedu.tinner.model.company.CompanyName;
 import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
 import seedu.tinner.model.company.Phone;
 import seedu.tinner.model.company.ReadOnlyRoleList;
 
@@ -98,8 +99,9 @@ public class EditCompanyCommand extends Command {
         Address updatedAddress =
                 editCompanyDescriptor.getAddress().orElse(companyToEdit.getAddress());
         ReadOnlyRoleList roles = companyToEdit.getRoleManager().getRoleList();
+        FavouriteStatus favouriteStatus = companyToEdit.getFavouriteStatus();
 
-        return new Company(updatedName, updatedPhone, updatedEmail, updatedAddress, roles);
+        return new Company(updatedName, updatedPhone, updatedEmail, updatedAddress, roles, favouriteStatus);
     }
 
     @Override

--- a/src/main/java/seedu/tinner/logic/commands/FavouriteCompanyCommand.java
+++ b/src/main/java/seedu/tinner/logic/commands/FavouriteCompanyCommand.java
@@ -1,0 +1,91 @@
+package seedu.tinner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.tinner.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
+import static seedu.tinner.model.company.RoleManager.PREDICATE_SHOW_ALL_ROLES;
+
+import java.util.List;
+
+import seedu.tinner.commons.core.Messages;
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.exceptions.CommandException;
+import seedu.tinner.model.Model;
+import seedu.tinner.model.company.Address;
+import seedu.tinner.model.company.Company;
+import seedu.tinner.model.company.CompanyName;
+import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
+import seedu.tinner.model.company.Phone;
+import seedu.tinner.model.company.ReadOnlyRoleList;
+
+
+/**
+ * Favourites a company identified using it's displayed index from the address book.
+ */
+public class FavouriteCompanyCommand extends Command {
+
+    public static final String COMMAND_WORD = "favourite";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Favourites the company identified by the index number used in the displayed company list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_FAVOURITE_COMPANY_SUCCESS = "Favourited Company: %1$s";
+
+    public static final String MESSAGE_ALREADY_FAVOURITED_COMPANY = "This company has already been favourited.";
+
+    private final Index targetIndex;
+
+    public FavouriteCompanyCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Company> lastShownList = model.getFilteredCompanyList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+        }
+
+        Company companyToFavourite = lastShownList.get(targetIndex.getZeroBased());
+
+        if (companyToFavourite.getFavouriteStatus().isFavourited) {
+            throw new CommandException(MESSAGE_ALREADY_FAVOURITED_COMPANY);
+        }
+
+        Company favouritedCompany = createFavouritedCompany(companyToFavourite);
+
+        model.setCompany(companyToFavourite, favouritedCompany);
+        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES, PREDICATE_SHOW_ALL_ROLES);
+
+        return new CommandResult(String.format(MESSAGE_FAVOURITE_COMPANY_SUCCESS, favouritedCompany));
+    }
+
+    /**
+     * Creates and returns a {@code Company} with the details of {@code companyToFavourite}
+     * other than its {@code FavouriteStatus} which is updated with the {@code isFavourited} field set to
+     * true
+     */
+    public static Company createFavouritedCompany(Company companyToFavourite) {
+        assert companyToFavourite != null;
+
+        CompanyName companyName = companyToFavourite.getName();
+        Phone phone = companyToFavourite.getPhone();
+        Email email = companyToFavourite.getEmail();
+        Address address = companyToFavourite.getAddress();
+        ReadOnlyRoleList roles = companyToFavourite.getRoleManager().getRoleList();
+        FavouriteStatus favouriteStatus = new FavouriteStatus(true);
+
+        return new Company(companyName, phone, email, address, roles, favouriteStatus);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FavouriteCompanyCommand // instanceof handles nulls
+                && targetIndex.equals(((FavouriteCompanyCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/tinner/logic/commands/ListFavouriteCommand.java
+++ b/src/main/java/seedu/tinner/logic/commands/ListFavouriteCommand.java
@@ -1,0 +1,25 @@
+package seedu.tinner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.tinner.model.company.RoleManager.PREDICATE_SHOW_ALL_ROLES;
+
+import seedu.tinner.model.Model;
+import seedu.tinner.model.company.CompanyHasBeenFavouritedPredicate;
+
+/**
+ * Lists all favourited companies in the address book to the user.
+ */
+public class ListFavouriteCommand extends Command {
+
+    public static final String COMMAND_WORD = "listFavourite";
+
+    public static final String MESSAGE_SUCCESS = "Listed all favourited companies";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        CompanyHasBeenFavouritedPredicate companyPredicate = new CompanyHasBeenFavouritedPredicate();
+        model.updateFilteredCompanyList(companyPredicate, PREDICATE_SHOW_ALL_ROLES);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/tinner/logic/commands/UnfavouriteCompanyCommand.java
+++ b/src/main/java/seedu/tinner/logic/commands/UnfavouriteCompanyCommand.java
@@ -1,0 +1,91 @@
+package seedu.tinner.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.tinner.model.Model.PREDICATE_SHOW_ALL_COMPANIES;
+import static seedu.tinner.model.company.RoleManager.PREDICATE_SHOW_ALL_ROLES;
+
+import java.util.List;
+
+import seedu.tinner.commons.core.Messages;
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.exceptions.CommandException;
+import seedu.tinner.model.Model;
+import seedu.tinner.model.company.Address;
+import seedu.tinner.model.company.Company;
+import seedu.tinner.model.company.CompanyName;
+import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
+import seedu.tinner.model.company.Phone;
+import seedu.tinner.model.company.ReadOnlyRoleList;
+
+
+/**
+ * Unfavourites a company identified using it's displayed index from the address book.
+ */
+public class UnfavouriteCompanyCommand extends Command {
+
+    public static final String COMMAND_WORD = "unfavourite";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Unfavourites the company identified by the index number used in the displayed company list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_UNFAVOURITE_COMPANY_SUCCESS = "Unfavourited Company: %1$s";
+
+    public static final String MESSAGE_ALREADY_UNFAVOURITED_COMPANY = "This company is already unfavourited.";
+
+    private final Index targetIndex;
+
+    public UnfavouriteCompanyCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Company> lastShownList = model.getFilteredCompanyList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+        }
+
+        Company companyToUnfavourite = lastShownList.get(targetIndex.getZeroBased());
+
+        if (!companyToUnfavourite.getFavouriteStatus().isFavourited) {
+            throw new CommandException(MESSAGE_ALREADY_UNFAVOURITED_COMPANY);
+        }
+
+        Company unfavouritedCompany = createUnfavouritedCompany(companyToUnfavourite);
+
+        model.setCompany(companyToUnfavourite, unfavouritedCompany);
+        model.updateFilteredCompanyList(PREDICATE_SHOW_ALL_COMPANIES, PREDICATE_SHOW_ALL_ROLES);
+
+        return new CommandResult(String.format(MESSAGE_UNFAVOURITE_COMPANY_SUCCESS, unfavouritedCompany));
+    }
+
+    /**
+     * Creates and returns a {@code Company} with the details of {@code companyToUnfavourite}
+     * other than its {@code FavouriteStatus} which is updated with the {@code isFavourited} field set to
+     * false
+     */
+    public static Company createUnfavouritedCompany(Company companyToUnfavourite) {
+        assert companyToUnfavourite != null;
+
+        CompanyName companyName = companyToUnfavourite.getName();
+        Phone phone = companyToUnfavourite.getPhone();
+        Email email = companyToUnfavourite.getEmail();
+        Address address = companyToUnfavourite.getAddress();
+        ReadOnlyRoleList roles = companyToUnfavourite.getRoleManager().getRoleList();
+        FavouriteStatus favouriteStatus = new FavouriteStatus(false);
+
+        return new Company(companyName, phone, email, address, roles, favouriteStatus);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnfavouriteCompanyCommand // instanceof handles nulls
+                && targetIndex.equals(((UnfavouriteCompanyCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/tinner/logic/parser/AddCompanyCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/AddCompanyCommandParser.java
@@ -13,8 +13,10 @@ import seedu.tinner.model.company.Address;
 import seedu.tinner.model.company.Company;
 import seedu.tinner.model.company.CompanyName;
 import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
 import seedu.tinner.model.company.Phone;
 import seedu.tinner.model.company.RoleList;
+
 
 /**
  * Parses input arguments and creates a new AddCompanyCommand object
@@ -50,9 +52,10 @@ public class AddCompanyCommandParser implements Parser<AddCompanyCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getOptionalValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getOptionalValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getOptionalValue(PREFIX_ADDRESS).get());
+
         RoleList roles = new RoleList();
 
-        Company company = new Company(name, phone, email, address, roles);
+        Company company = new Company(name, phone, email, address, roles, new FavouriteStatus(false));
 
         return new AddCompanyCommand(company);
     }

--- a/src/main/java/seedu/tinner/logic/parser/CompanyListParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/CompanyListParser.java
@@ -15,9 +15,12 @@ import seedu.tinner.logic.commands.DeleteRoleCommand;
 import seedu.tinner.logic.commands.EditCompanyCommand;
 import seedu.tinner.logic.commands.EditRoleCommand;
 import seedu.tinner.logic.commands.ExitCommand;
+import seedu.tinner.logic.commands.FavouriteCompanyCommand;
 import seedu.tinner.logic.commands.FindCommand;
 import seedu.tinner.logic.commands.HelpCommand;
 import seedu.tinner.logic.commands.ListCommand;
+import seedu.tinner.logic.commands.ListFavouriteCommand;
+import seedu.tinner.logic.commands.UnfavouriteCompanyCommand;
 import seedu.tinner.logic.parser.exceptions.ParseException;
 
 /**
@@ -65,6 +68,9 @@ public class CompanyListParser {
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
 
+        case ListFavouriteCommand.COMMAND_WORD:
+            return new ListFavouriteCommand();
+
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
 
@@ -79,6 +85,12 @@ public class CompanyListParser {
 
         case EditRoleCommand.COMMAND_WORD:
             return new EditRoleCommandParser().parse(arguments);
+
+        case FavouriteCompanyCommand.COMMAND_WORD:
+            return new FavouriteCompanyCommandParser().parse(arguments);
+
+        case UnfavouriteCompanyCommand.COMMAND_WORD:
+            return new UnfavouriteCompanyCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/tinner/logic/parser/FavouriteCompanyCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/FavouriteCompanyCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.tinner.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.FavouriteCompanyCommand;
+import seedu.tinner.logic.parser.exceptions.ParseException;
+
+/**
+ *  Parses input arguments and creates a new FavouriteCompanyCommand object
+ */
+public class FavouriteCompanyCommandParser implements Parser<FavouriteCompanyCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the FavouriteCompanyCommand
+     * and returns an FavouriteCompanyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FavouriteCompanyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        Index companyIndex;
+
+        try {
+            companyIndex = ParserUtil.parseIndex(args);
+            return new FavouriteCompanyCommand(companyIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavouriteCompanyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/tinner/logic/parser/UnfavouriteCompanyCommandParser.java
+++ b/src/main/java/seedu/tinner/logic/parser/UnfavouriteCompanyCommandParser.java
@@ -1,0 +1,31 @@
+package seedu.tinner.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.UnfavouriteCompanyCommand;
+import seedu.tinner.logic.parser.exceptions.ParseException;
+
+/**
+ *  Parses input arguments and creates a new UnfavouriteCompanyCommand object
+ */
+public class UnfavouriteCompanyCommandParser implements Parser<UnfavouriteCompanyCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnfavouriteCompanyCommand
+     * and returns an UnfavouriteCompanyCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnfavouriteCompanyCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        Index companyIndex;
+
+        try {
+            companyIndex = ParserUtil.parseIndex(args);
+            return new UnfavouriteCompanyCommand(companyIndex);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnfavouriteCompanyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/tinner/model/Model.java
+++ b/src/main/java/seedu/tinner/model/Model.java
@@ -18,6 +18,11 @@ public interface Model {
     Predicate<Company> PREDICATE_SHOW_ALL_COMPANIES = unused -> true;
 
     /**
+     * {@code Predicate} that always evaluate to false, for filtering companies.
+     */
+    Predicate<Company> PREDICATE_SHOW_NO_COMPANIES = unused -> false;
+
+    /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */
     void setUserPrefs(ReadOnlyUserPrefs userPrefs);

--- a/src/main/java/seedu/tinner/model/company/Company.java
+++ b/src/main/java/seedu/tinner/model/company/Company.java
@@ -14,6 +14,7 @@ public class Company {
     private final CompanyName companyName;
     private final Phone phone;
     private final Email email;
+    private final FavouriteStatus favouriteStatus;
 
     // Data fields
     private final Address address;
@@ -22,13 +23,15 @@ public class Company {
     /**
      * Name is compulsory but Phone, Email and Address are optional
      */
-    public Company(CompanyName companyName, Phone phone, Email email, Address address, ReadOnlyRoleList roles) {
+    public Company(CompanyName companyName, Phone phone, Email email, Address address, ReadOnlyRoleList roles,
+                   FavouriteStatus favouriteStatus) {
         requireAllNonNull(companyName, phone, email, address);
         this.companyName = companyName;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.roleManager.setRoleList(roles);
+        this.favouriteStatus = favouriteStatus;
     }
 
     public CompanyName getName() {
@@ -47,6 +50,9 @@ public class Company {
         return address;
     }
 
+    public FavouriteStatus getFavouriteStatus() {
+        return favouriteStatus;
+    }
 
     public RoleManager getRoleManager() {
         return roleManager;
@@ -83,13 +89,14 @@ public class Company {
         return otherCompany.getName().equals(getName())
                 && otherCompany.getPhone().equals(getPhone())
                 && otherCompany.getEmail().equals(getEmail())
-                && otherCompany.getAddress().equals(getAddress());
+                && otherCompany.getAddress().equals(getAddress())
+                && otherCompany.getFavouriteStatus().equals(getFavouriteStatus());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(companyName, phone, email, address);
+        return Objects.hash(companyName, phone, email, address, favouriteStatus);
     }
 
     @Override
@@ -101,7 +108,9 @@ public class Company {
                 .append("; Email: ")
                 .append(getEmail())
                 .append("; Address: ")
-                .append(getAddress());
+                .append(getAddress())
+                .append("; Favourite: ")
+                .append(getFavouriteStatus());
 
         return builder.toString();
     }

--- a/src/main/java/seedu/tinner/model/company/CompanyHasBeenFavouritedPredicate.java
+++ b/src/main/java/seedu/tinner/model/company/CompanyHasBeenFavouritedPredicate.java
@@ -1,0 +1,26 @@
+package seedu.tinner.model.company;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Company} has been favourited by the user.
+ */
+public class CompanyHasBeenFavouritedPredicate implements Predicate<Company> {
+
+    public CompanyHasBeenFavouritedPredicate() {
+
+    }
+
+    @Override
+    public boolean test(Company company) {
+        return company.getFavouriteStatus().isFavourited;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                // instanceof handles nulls
+                || other instanceof CompanyHasBeenFavouritedPredicate;
+    }
+
+}

--- a/src/main/java/seedu/tinner/model/company/FavouriteStatus.java
+++ b/src/main/java/seedu/tinner/model/company/FavouriteStatus.java
@@ -1,0 +1,42 @@
+package seedu.tinner.model.company;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents a Company's favourite status in the address book.
+ * Guarantees: immutable
+ */
+public class FavouriteStatus {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Favourite should only contain numbers, and it should be at least 3 digits long";
+    public final Boolean isFavourited;
+
+    /**
+     * Constructs a {@code FavouriteStatus}.
+     *
+     * @param isFavourited A Boolean value
+     */
+    public FavouriteStatus(Boolean isFavourited) {
+        requireNonNull(isFavourited);
+        this.isFavourited = isFavourited;
+    }
+
+    @Override
+    public String toString() {
+        return isFavourited.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FavouriteStatus // instanceof handles nulls
+                && (isFavourited == ((FavouriteStatus) other).isFavourited)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return isFavourited.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/tinner/model/company/RoleManager.java
+++ b/src/main/java/seedu/tinner/model/company/RoleManager.java
@@ -19,6 +19,11 @@ public class RoleManager {
      */
     public static final Predicate<Role> PREDICATE_SHOW_ALL_ROLES = unused -> true;
 
+    /**
+     * {@code Predicate} that always evaluate to false
+     */
+    public static final Predicate<Role> PREDICATE_SHOW_NO_ROLES = unused -> false;
+
     private final RoleList roleList;
     private final FilteredList<Role> filteredRoles;
 

--- a/src/main/java/seedu/tinner/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/tinner/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import seedu.tinner.model.company.Address;
 import seedu.tinner.model.company.Company;
 import seedu.tinner.model.company.CompanyName;
 import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
 import seedu.tinner.model.company.Phone;
 import seedu.tinner.model.company.RoleList;
 import seedu.tinner.model.role.Deadline;
@@ -44,17 +45,23 @@ public class SampleDataUtil {
 
         return new Company[]{
                 new Company(new CompanyName("Meta"), new Phone("87438807"), new Email("alexyeoh@example.com"),
-                        new Address("Blk 30 Geylang Street 29, #06-40"), SAMPLE_ROLES_1),
+                        new Address("Blk 30 Geylang Street 29, #06-40"), SAMPLE_ROLES_1,
+                        new FavouriteStatus(false)),
                 new Company(new CompanyName("Amazon"), new Phone("99272758"), new Email("berniceyu@example.com"),
-                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), SAMPLE_ROLES_1),
+                        new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), SAMPLE_ROLES_1,
+                        new FavouriteStatus(false)),
                 new Company(new CompanyName("Netflix"), new Phone("93210283"), new Email("charlotte@example.com"),
-                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), SAMPLE_ROLES_2),
+                        new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), SAMPLE_ROLES_2,
+                        new FavouriteStatus(false)),
                 new Company(new CompanyName("Google"), new Phone("91031282"), new Email("lidavid@example.com"),
-                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), SAMPLE_ROLES_2),
+                        new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), SAMPLE_ROLES_2,
+                        new FavouriteStatus(false)),
                 new Company(new CompanyName("Apple"), new Phone("92492021"), new Email("irfan@example.com"),
-                        new Address("Blk 47 Tampines Street 20, #17-35"), SAMPLE_ROLES_3),
+                        new Address("Blk 47 Tampines Street 20, #17-35"), SAMPLE_ROLES_3,
+                        new FavouriteStatus(false)),
                 new Company(new CompanyName("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
-                        new Address("Blk 45 Aljunied Street 85, #11-31"), SAMPLE_ROLES_3)
+                        new Address("Blk 45 Aljunied Street 85, #11-31"), SAMPLE_ROLES_3,
+                        new FavouriteStatus(false))
         };
     }
 

--- a/src/main/java/seedu/tinner/storage/JsonAdaptedCompany.java
+++ b/src/main/java/seedu/tinner/storage/JsonAdaptedCompany.java
@@ -12,6 +12,7 @@ import seedu.tinner.model.company.Address;
 import seedu.tinner.model.company.Company;
 import seedu.tinner.model.company.CompanyName;
 import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
 import seedu.tinner.model.company.Phone;
 import seedu.tinner.model.company.RoleList;
 
@@ -107,7 +108,8 @@ class JsonAdaptedCompany {
 
         final RoleList modelRoles = new RoleList(companyRoles);
 
-        return new Company(modelName, modelPhone, modelEmail, modelAddress, modelRoles);
+        return new Company(modelName, modelPhone, modelEmail, modelAddress, modelRoles,
+                new FavouriteStatus(false));
     }
 
 }

--- a/src/test/java/seedu/tinner/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/tinner/logic/commands/CommandTestUtil.java
@@ -2,6 +2,7 @@ package seedu.tinner.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.tinner.logic.commands.FavouriteCompanyCommand.createFavouritedCompany;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static seedu.tinner.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
@@ -151,6 +152,18 @@ public class CommandTestUtil {
                         Arrays.asList(splitName)), PREDICATE_SHOW_ALL_ROLES);
 
         assertEquals(1, model.getFilteredCompanyList().size());
+    }
+
+    /**
+     * Updates {@code model}'s list to favourite the company at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void favouriteCompanyAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredCompanyList().size());
+        Company companyToFavourite = model.getFilteredCompanyList().get(targetIndex.getZeroBased());
+        Company favouritedCompany = createFavouritedCompany(companyToFavourite);
+        assertTrue(favouritedCompany.getFavouriteStatus().isFavourited);
+        model.setCompany(companyToFavourite, favouritedCompany);
     }
 
 }

--- a/src/test/java/seedu/tinner/logic/commands/FavouriteCompanyCommandTest.java
+++ b/src/test/java/seedu/tinner/logic/commands/FavouriteCompanyCommandTest.java
@@ -1,0 +1,117 @@
+package seedu.tinner.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.tinner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.tinner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.tinner.logic.commands.CommandTestUtil.favouriteCompanyAtIndex;
+import static seedu.tinner.logic.commands.CommandTestUtil.showCompanyAtIndex;
+import static seedu.tinner.testutil.TypicalCompanies.getTypicalCompanyList;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_SECOND_COMPANY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.tinner.commons.core.Messages;
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.model.Model;
+import seedu.tinner.model.ModelManager;
+import seedu.tinner.model.UserPrefs;
+import seedu.tinner.model.company.Company;
+import seedu.tinner.testutil.CompanyBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code FavouriteCompanyCommand}.
+ */
+public class FavouriteCompanyCommandTest {
+
+    private Model model = new ModelManager(getTypicalCompanyList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Company companyToFavourite = model.getFilteredCompanyList().get(INDEX_FIRST_COMPANY.getZeroBased());
+        FavouriteCompanyCommand favouriteCompanyCommand = new FavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        Company favouritedCompany = new CompanyBuilder(companyToFavourite).setToFavourite().build();
+
+        String expectedMessage = String.format(FavouriteCompanyCommand.MESSAGE_FAVOURITE_COMPANY_SUCCESS,
+                favouritedCompany);
+
+        Model expectedModel = new ModelManager(model.getCompanyList(), new UserPrefs());
+        expectedModel.setCompany(companyToFavourite, favouritedCompany);
+
+        assertCommandSuccess(favouriteCompanyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCompanyList().size() + 1);
+        FavouriteCompanyCommand favouriteCompanyCommand = new FavouriteCompanyCommand(outOfBoundIndex);
+
+        assertCommandFailure(favouriteCompanyCommand, model, Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+
+        Company companyToFavourite = model.getFilteredCompanyList().get(INDEX_FIRST_COMPANY.getZeroBased());
+        FavouriteCompanyCommand favouriteCompanyCommand = new FavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        Company favouritedCompany = new CompanyBuilder(companyToFavourite).setToFavourite().build();
+
+        String expectedMessage = String.format(FavouriteCompanyCommand.MESSAGE_FAVOURITE_COMPANY_SUCCESS,
+                favouritedCompany);
+
+        Model expectedModel = new ModelManager(model.getCompanyList(), new UserPrefs());
+        expectedModel.setCompany(companyToFavourite, favouritedCompany);
+
+        assertCommandSuccess(favouriteCompanyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+
+        Index outOfBoundIndex = INDEX_SECOND_COMPANY;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getCompanyList().getCompanyList().size());
+
+        FavouriteCompanyCommand favouriteCompanyCommand = new FavouriteCompanyCommand(outOfBoundIndex);
+
+        assertCommandFailure(favouriteCompanyCommand, model, Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_companyAlreadyFavourited_throwsCommandException() {
+        favouriteCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+
+        FavouriteCompanyCommand favouriteCompanyCommand = new FavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        assertCommandFailure(favouriteCompanyCommand, model,
+                FavouriteCompanyCommand.MESSAGE_ALREADY_FAVOURITED_COMPANY);
+    }
+
+    @Test
+    public void equals() {
+        FavouriteCompanyCommand favouriteFirstCommand = new FavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+        FavouriteCompanyCommand favouriteSecondCommand = new FavouriteCompanyCommand(INDEX_SECOND_COMPANY);
+
+        // same object -> returns true
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommand));
+
+        // same values -> returns true
+        FavouriteCompanyCommand favouriteFirstCommandCopy = new FavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+        assertTrue(favouriteFirstCommand.equals(favouriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(favouriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(favouriteFirstCommand.equals(null));
+
+        // different company -> returns false
+        assertFalse(favouriteFirstCommand.equals(favouriteSecondCommand));
+    }
+}

--- a/src/test/java/seedu/tinner/logic/commands/ListFavouriteCommandTest.java
+++ b/src/test/java/seedu/tinner/logic/commands/ListFavouriteCommandTest.java
@@ -1,0 +1,45 @@
+package seedu.tinner.logic.commands;
+
+import static seedu.tinner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.tinner.logic.commands.CommandTestUtil.favouriteCompanyAtIndex;
+import static seedu.tinner.logic.commands.CommandTestUtil.showCompanyAtIndex;
+import static seedu.tinner.model.Model.PREDICATE_SHOW_NO_COMPANIES;
+import static seedu.tinner.model.company.RoleManager.PREDICATE_SHOW_NO_ROLES;
+import static seedu.tinner.testutil.TypicalCompanies.getTypicalCompanyList;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_SECOND_COMPANY;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.tinner.model.Model;
+import seedu.tinner.model.ModelManager;
+import seedu.tinner.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListFavouriteCommand.
+ */
+public class ListFavouriteCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalCompanyList(), new UserPrefs());
+        expectedModel = new ModelManager(model.getCompanyList(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_noCompanyFavourited_showsEmptyList() {
+        expectedModel.updateFilteredCompanyList(PREDICATE_SHOW_NO_COMPANIES, PREDICATE_SHOW_NO_ROLES);
+        assertCommandSuccess(new ListFavouriteCommand(), model, ListFavouriteCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_oneRoleFavourited_showsFavouritedRole() {
+        favouriteCompanyAtIndex(expectedModel, INDEX_SECOND_COMPANY);
+        showCompanyAtIndex(expectedModel, INDEX_SECOND_COMPANY);
+        favouriteCompanyAtIndex(model, INDEX_SECOND_COMPANY);
+        assertCommandSuccess(new ListFavouriteCommand(), model, ListFavouriteCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/tinner/logic/commands/UnfavouriteCompanyCommandTest.java
+++ b/src/test/java/seedu/tinner/logic/commands/UnfavouriteCompanyCommandTest.java
@@ -1,0 +1,117 @@
+package seedu.tinner.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.tinner.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.tinner.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.tinner.logic.commands.CommandTestUtil.favouriteCompanyAtIndex;
+import static seedu.tinner.logic.commands.CommandTestUtil.showCompanyAtIndex;
+import static seedu.tinner.testutil.TypicalCompanies.getTypicalCompanyList;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_SECOND_COMPANY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.tinner.commons.core.Messages;
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.model.Model;
+import seedu.tinner.model.ModelManager;
+import seedu.tinner.model.UserPrefs;
+import seedu.tinner.model.company.Company;
+import seedu.tinner.testutil.CompanyBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code UnfavouriteCompanyCommand}.
+ */
+public class UnfavouriteCompanyCommandTest {
+
+    private Model model = new ModelManager(getTypicalCompanyList(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        favouriteCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+        Company companyToUnfavourite = model.getFilteredCompanyList().get(INDEX_FIRST_COMPANY.getZeroBased());
+        UnfavouriteCompanyCommand unfavouriteCompanyCommand = new UnfavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        Company unfavouritedCompany = new CompanyBuilder(companyToUnfavourite).setToUnfavourite().build();
+
+        String expectedMessage = String.format(UnfavouriteCompanyCommand.MESSAGE_UNFAVOURITE_COMPANY_SUCCESS,
+                unfavouritedCompany);
+
+        Model expectedModel = new ModelManager(model.getCompanyList(), new UserPrefs());
+        expectedModel.setCompany(companyToUnfavourite, unfavouritedCompany);
+
+        assertCommandSuccess(unfavouriteCompanyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredCompanyList().size() + 1);
+        UnfavouriteCompanyCommand unfavouriteCompanyCommand = new UnfavouriteCompanyCommand(outOfBoundIndex);
+
+        assertCommandFailure(unfavouriteCompanyCommand, model, Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        favouriteCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+        showCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+
+        Company companyToUnfavourite = model.getFilteredCompanyList().get(INDEX_FIRST_COMPANY.getZeroBased());
+        UnfavouriteCompanyCommand unfavouriteCompanyCommand = new UnfavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        Company unfavouritedCompany = new CompanyBuilder(companyToUnfavourite).setToUnfavourite().build();
+
+        String expectedMessage = String.format(UnfavouriteCompanyCommand.MESSAGE_UNFAVOURITE_COMPANY_SUCCESS,
+                unfavouritedCompany);
+
+        Model expectedModel = new ModelManager(model.getCompanyList(), new UserPrefs());
+        expectedModel.setCompany(companyToUnfavourite, unfavouritedCompany);
+
+        assertCommandSuccess(unfavouriteCompanyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showCompanyAtIndex(model, INDEX_FIRST_COMPANY);
+
+        Index outOfBoundIndex = INDEX_SECOND_COMPANY;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getCompanyList().getCompanyList().size());
+
+        UnfavouriteCompanyCommand favouriteCompanyCommand = new UnfavouriteCompanyCommand(outOfBoundIndex);
+
+        assertCommandFailure(favouriteCompanyCommand, model, Messages.MESSAGE_INVALID_COMPANY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_companyAlreadyUnfavourited_throwsCommandException() {
+        UnfavouriteCompanyCommand unfavouriteCompanyCommand = new UnfavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+
+        assertCommandFailure(unfavouriteCompanyCommand, model,
+                UnfavouriteCompanyCommand.MESSAGE_ALREADY_UNFAVOURITED_COMPANY);
+    }
+
+    @Test
+    public void equals() {
+        UnfavouriteCompanyCommand unfavouriteFirstCommand = new UnfavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+        UnfavouriteCompanyCommand unfavouriteSecondCommand = new UnfavouriteCompanyCommand(INDEX_SECOND_COMPANY);
+
+        // same object -> returns true
+        assertTrue(unfavouriteFirstCommand.equals(unfavouriteFirstCommand));
+
+        // same values -> returns true
+        UnfavouriteCompanyCommand unfavouriteFirstCommandCopy = new UnfavouriteCompanyCommand(INDEX_FIRST_COMPANY);
+        assertTrue(unfavouriteFirstCommand.equals(unfavouriteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(null));
+
+        // different company -> returns false
+        assertFalse(unfavouriteFirstCommand.equals(unfavouriteSecondCommand));
+    }
+}

--- a/src/test/java/seedu/tinner/logic/parser/FavouriteCompanyCommandParserTest.java
+++ b/src/test/java/seedu/tinner/logic/parser/FavouriteCompanyCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.tinner.logic.parser;
+
+import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_INDEX_DESC;
+import static seedu.tinner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.tinner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_SECOND_COMPANY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.FavouriteCompanyCommand;
+
+public class FavouriteCompanyCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, FavouriteCompanyCommand.MESSAGE_USAGE);
+
+    private FavouriteCompanyCommandParser parser = new FavouriteCompanyCommandParser();
+
+    @Test
+    public void parse_missingIndex_failure() {
+        // no index specified
+        assertParseFailure(parser, INVALID_INDEX_DESC, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5", MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0", MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_validIndex_success() {
+        Index targetIndex = INDEX_SECOND_COMPANY;
+        String userInput = String.valueOf(targetIndex.getOneBased());
+
+        FavouriteCompanyCommand expectedCommand = new FavouriteCompanyCommand(targetIndex);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/tinner/logic/parser/UnfavouriteCompanyCommandParserTest.java
+++ b/src/test/java/seedu/tinner/logic/parser/UnfavouriteCompanyCommandParserTest.java
@@ -1,0 +1,47 @@
+package seedu.tinner.logic.parser;
+
+import static seedu.tinner.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.tinner.logic.commands.CommandTestUtil.INVALID_INDEX_DESC;
+import static seedu.tinner.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.tinner.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.tinner.testutil.TypicalIndexes.INDEX_SECOND_COMPANY;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.tinner.commons.core.index.Index;
+import seedu.tinner.logic.commands.UnfavouriteCompanyCommand;
+
+public class UnfavouriteCompanyCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnfavouriteCompanyCommand.MESSAGE_USAGE);
+
+    private UnfavouriteCompanyCommandParser parser = new UnfavouriteCompanyCommandParser();
+
+    @Test
+    public void parse_missingIndex_failure() {
+        // no index specified
+        assertParseFailure(parser, INVALID_INDEX_DESC, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative index
+        assertParseFailure(parser, "-5", MESSAGE_INVALID_FORMAT);
+
+        // zero index
+        assertParseFailure(parser, "0", MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_validIndex_success() {
+        Index targetIndex = INDEX_SECOND_COMPANY;
+        String userInput = String.valueOf(targetIndex.getOneBased());
+
+        UnfavouriteCompanyCommand expectedCommand = new UnfavouriteCompanyCommand(targetIndex);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/tinner/model/role/FavouriteStatusTest.java
+++ b/src/test/java/seedu/tinner/model/role/FavouriteStatusTest.java
@@ -4,13 +4,12 @@ import static seedu.tinner.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.tinner.model.company.RoleManager;
+import seedu.tinner.model.company.FavouriteStatus;
 
-public class RoleManagerTest {
+public class FavouriteStatusTest {
 
     @Test
     public void constructor_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () ->
-                new RoleManager(null));
+        assertThrows(NullPointerException.class, () -> new FavouriteStatus(null));
     }
 }

--- a/src/test/java/seedu/tinner/testutil/CompanyBuilder.java
+++ b/src/test/java/seedu/tinner/testutil/CompanyBuilder.java
@@ -6,6 +6,7 @@ import seedu.tinner.model.company.Address;
 import seedu.tinner.model.company.Company;
 import seedu.tinner.model.company.CompanyName;
 import seedu.tinner.model.company.Email;
+import seedu.tinner.model.company.FavouriteStatus;
 import seedu.tinner.model.company.Phone;
 import seedu.tinner.model.company.ReadOnlyRoleList;
 import seedu.tinner.model.company.RoleList;
@@ -25,6 +26,7 @@ public class CompanyBuilder {
     private Phone phone;
     private Email email;
     private Address address;
+    private FavouriteStatus favouriteStatus;
     private ReadOnlyRoleList roles;
 
     /**
@@ -35,6 +37,7 @@ public class CompanyBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        favouriteStatus = new FavouriteStatus(false);
         roles = new RoleList();
     }
 
@@ -47,6 +50,7 @@ public class CompanyBuilder {
         email = companyToCopy.getEmail();
         address = companyToCopy.getAddress();
         roles = companyToCopy.getRoleManager().getRoleList();
+        favouriteStatus = companyToCopy.getFavouriteStatus();
     }
 
     /**
@@ -115,8 +119,26 @@ public class CompanyBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code isFavourited} field of {@code FavouriteStatus} in the {@code Company}
+     * that we are building to true.
+     */
+    public CompanyBuilder setToFavourite() {
+        this.favouriteStatus = new FavouriteStatus(true);
+        return this;
+    }
+
+    /**
+     * Sets the {@code isFavourited} field of {@code FavouriteStatus} in the {@code Company}
+     * that we are building to false.
+     */
+    public CompanyBuilder setToUnfavourite() {
+        this.favouriteStatus = new FavouriteStatus(false);
+        return this;
+    }
+
     public Company build() {
-        return new Company(name, phone, email, address, roles);
+        return new Company(name, phone, email, address, roles, favouriteStatus);
     }
 
 }


### PR DESCRIPTION
- Created a new field FavouriteStatus within a Company to track whether a company is favourited

- Created new Parser classes to Parse favourite, unfavourite and listFavourite Commands

- The listFavourite command works similarly to the find command, where a predicate where only companies which are favourited returns true is set to the filtered company list.

- Basic testing for new command and parser classes, and for the previously created RoleManager class

- Updated User Guide with new commands