### PR TITLE
Add maximum length enforcement to CompanyName, RoleName and Phone fields

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -230,7 +230,7 @@ The following points explain the format of a command.
 
 ### Company Restrictions <a id="c-company-restrictions"></a>
 
-* The `COMPANY_NAME` should only contain alphanumeric characters and spaces, but not blank, and have a character limit of at most 30.
+* The `COMPANY_NAME` should only contain alphanumeric characters and spaces, and have a character limit of at most 30.
 * The `PHONE_NUMBER` should only contain numbers, and be at least 3 digits long and at most 14 digits.
 * The `EMAIL` should be of the format local-part@domain and adhere to the following constraints:
     * The local-part should only contain alphanumeric characters and these special characters, excluding the
@@ -254,7 +254,7 @@ The following points explain the format of a command.
 
 ### Role Restrictions <a id="c-role-restrictions"></a>
 
-* The `ROLE_NAME` should only contain alphanumeric characters, spaces and an optional pair of round brackets, but not blank, and have a character limit of at most 30.
+* The `ROLE_NAME` should only contain alphanumeric characters, spaces and an optional pair of round brackets and have a character limit of at most 30.
 * The `REMINDER_DATE` should not be in the past and must be a valid date 
 in the following format: dd-MM-yyyy HH:mm.
 * The `STATUS` is case-sensitive and can only accept the following inputs:
@@ -454,7 +454,7 @@ not, `editCompany` has got you covered. Simply edit the parts of the company det
   The index must be a positive integer 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* The `PHONE_NUMBER`, `EMAIL` and `ADDRESS` here can be left blank, allowing you to remove previously added information which may be erroneous.
+  * `PHONE_NUMBER`, `EMAIL` and `ADDRESS` fields can be left blank, allowing you to remove previously added information which may be erroneous.
 * More restrictions for command parameters can be found [here](#c-company-restrictions)
 
 **Examples:**
@@ -587,11 +587,7 @@ company.
 
 </div>
 
-<div markdown="block" class="alert alert-danger">
 
-:warning: If a prefix is specified, even for optional fields, the value after the prefix cannot be blank. e.g. `$/` only is not valid but `$/1000` is valid.
-
-</div>
 
 
 
@@ -610,8 +606,9 @@ Just got invited to an interview? Keep your internship role status and other det
   the index number shown in the displayed company list. The indexes must be a positive integer 1, 2, 3, …​
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
-* The `REMINDER_DATE`, `DESCRIPTION` and `STIPEND` here can be left blank, allowing you to remove previously added information which may be erroneous.
+  * `REMINDER_DATE`, `DESCRIPTION` and `STIPEND` fields can be left blank, allowing you to remove previously added information which may be erroneous.
 * More restrictions for command parameters can be found [here](#c-role-restrictions)
+
 
 **Examples:**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -230,8 +230,8 @@ The following points explain the format of a command.
 
 ### Company Restrictions <a id="c-company-restrictions"></a>
 
-* The `COMPANY_NAME` should only contain alphanumeric characters and spaces, and it should not be blank.
-* The `PHONE_NUMBER` should only contain numbers, and it should be at least 3 digits long.
+* The `COMPANY_NAME` should only contain alphanumeric characters and spaces, but not blank, and have a character limit of at most 30.
+* The `PHONE_NUMBER` should only contain numbers, and be at least 3 digits long and at most 14 digits.
 * The `EMAIL` should be of the format local-part@domain and adhere to the following constraints:
     * The local-part should only contain alphanumeric characters and these special characters, excluding the
       parentheses, (+_.-).
@@ -254,7 +254,7 @@ The following points explain the format of a command.
 
 ### Role Restrictions <a id="c-role-restrictions"></a>
 
-* The `ROLE_NAME` should only contain alphanumeric characters, spaces and an optional pair of round brackets.
+* The `ROLE_NAME` should only contain alphanumeric characters, spaces and an optional pair of round brackets, but not blank, and have a character limit of at most 30.
 * The `REMINDER_DATE` should not be in the past and must be a valid date 
 in the following format: dd-MM-yyyy HH:mm.
 * The `STATUS` is case-sensitive and can only accept the following inputs:

--- a/src/main/java/seedu/tinner/model/company/CompanyName.java
+++ b/src/main/java/seedu/tinner/model/company/CompanyName.java
@@ -10,9 +10,9 @@ import static seedu.tinner.commons.util.AppUtil.checkArgument;
 public class CompanyName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Company names should only contain alphanumeric characters and spaces, with character length at most 30";
 
-    /*
+    /**
      * The first character of the Name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
@@ -32,10 +32,10 @@ public class CompanyName {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid name and it is within the maximum length of 30.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return (test.length() <= 30) && (test.matches(VALIDATION_REGEX));
     }
 
 

--- a/src/main/java/seedu/tinner/model/company/Phone.java
+++ b/src/main/java/seedu/tinner/model/company/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be at least 3 digits long and at most 14 digits";
+    public static final String VALIDATION_REGEX = "\\d{3,14}";
     public final String value;
 
     /**

--- a/src/main/java/seedu/tinner/model/role/RoleName.java
+++ b/src/main/java/seedu/tinner/model/role/RoleName.java
@@ -10,10 +10,10 @@ import static seedu.tinner.commons.util.AppUtil.checkArgument;
 public class RoleName {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters, spaces and an optional pair of round brackets, "
-                    + "and it should not be blank";
+            "Role names should only contain alphanumeric characters, spaces and an optional pair of round brackets, "
+                    + "but not blank, and have a character limit of at most 30";
 
-    /*
+    /**
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
@@ -36,7 +36,7 @@ public class RoleName {
      * Returns true if a given string is a valid name.
      */
     public static boolean isValidName(String test) {
-        return test.matches(VALIDATION_REGEX) && areValidBrackets(test);
+        return (test.length() <= 30) && (test.matches(VALIDATION_REGEX)) && areValidBrackets(test);
     }
 
     private static boolean areValidBrackets(String test) {

--- a/src/test/java/seedu/tinner/model/company/CompanyNameTest.java
+++ b/src/test/java/seedu/tinner/model/company/CompanyNameTest.java
@@ -31,13 +31,14 @@ public class CompanyNameTest {
         assertFalse(CompanyName.isValidName(" ")); // spaces only
         assertFalse(CompanyName.isValidName("^")); // only non-alphanumeric characters
         assertFalse(CompanyName.isValidName("peter*")); // contains non-alphanumeric characters
+        assertFalse(CompanyName.isValidName("David Roger Jackson Ray Jr 2nd Son")); // long names exceeding max
 
         // valid name
         assertTrue(CompanyName.isValidName("peter jack")); // alphabets only
         assertTrue(CompanyName.isValidName("12345")); // numbers only
         assertTrue(CompanyName.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(CompanyName.isValidName("Capital Tan")); // with capital letters
-        assertTrue(CompanyName.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(CompanyName.isValidName("David Roger Jackson Ray Jr 2nd")); // long names within max
     }
 
     @Test

--- a/src/test/java/seedu/tinner/model/company/PhoneTest.java
+++ b/src/test/java/seedu/tinner/model/company/PhoneTest.java
@@ -30,11 +30,11 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("124293842033123")); // long phone numbers
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("")); // empty string
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("93121534999999")); // exactly 14 numbers
     }
 }

--- a/src/test/java/seedu/tinner/model/role/RoleNameTest.java
+++ b/src/test/java/seedu/tinner/model/role/RoleNameTest.java
@@ -40,9 +40,11 @@ public class RoleNameTest {
         assertFalse(RoleName.isValidName("teacher (test.)")); // alphanumeric, brackets and dot
         assertFalse(RoleName.isValidName("staff (.)  ( admin")); //alphanumeric, wrong order brackets and dot
         assertFalse(RoleName.isValidName("(Backend)")); // brackets containing alphanumeric only
+        assertFalse(RoleName.isValidName("Database Management and Server Integration")); // long names exceed max
 
         // valid name
-        assertTrue(RoleName.isValidName("Database Management and Server Integration")); // long names
+        assertTrue(RoleName.isValidName("Database and Server Management")); // long names within max
+        assertTrue(RoleName.isValidName("D(abase and Server Management)")); // long names within max with brackets
         assertTrue(RoleName.isValidName("12345")); // numbers only
         assertTrue(RoleName.isValidName("data analyst 2")); // alphanumeric characters
         assertTrue(RoleName.isValidName("Frontend Developer")); // with capital letters


### PR DESCRIPTION
- CompanyName and RoleName now only accept values up to 30 characters long
- Phone now only accept values up to 14 characters long
- Updated User Guide and error message accordingly to reflect this change